### PR TITLE
Expand framer udp ports

### DIFF
--- a/lib/ethernet/drat2eth_framer.sv
+++ b/lib/ethernet/drat2eth_framer.sv
@@ -33,10 +33,10 @@ module drat2eth_framer
 
    input logic        csr_enable,
    output logic       csr_idle,
-                      // DRaT protocol input bus (64b TDATA)
-                      axis_t.slave in_axis,
-                      // Ethernet/IPv4/UDP encapsulated output bus (68b TDATA)
-                      axis_t.master out_axis
+   // DRaT protocol input bus (64b TDATA)
+   axis_t.slave in_axis,
+   // Ethernet/IPv4/UDP encapsulated output bus (68b TDATA)
+   axis_t.master out_axis
 
    );
 

--- a/lib/ethernet/ethernet.sv
+++ b/lib/ethernet/ethernet.sv
@@ -540,11 +540,11 @@ class UDPPacket extends IPv4Packet;
       integer payload_len;
       logic [63:0] beat;
 
-      axis_bus.push_beat({this.eth_header[31:0],ipv4_header[159:128]},0);
-      axis_bus.push_beat(this.ipv4_header[127:64],0);
-      axis_bus.push_beat(this.ipv4_header[63:0],0);
+      axis_bus.write_beat({this.eth_header[31:0],ipv4_header[159:128]},0);
+      axis_bus.write_beat(this.ipv4_header[127:64],0);
+      axis_bus.write_beat(this.ipv4_header[63:0],0);
       // If we support UDP with 0 payload length then this next burst needs TLAST support.
-      axis_bus.push_beat(this.udp_header[63:0],0);
+      axis_bus.write_beat(this.udp_header[63:0],0);
       payload_len = this.udp_header.length - 8;
       if (use_assertion) begin
          assert(payload_len==this.get_payload_length());
@@ -559,14 +559,14 @@ class UDPPacket extends IPv4Packet;
          for (integer i=0; i < 8; i++) begin
             beat = (beat << 8) | this.get_payload_octet();
          end
-         axis_bus.push_beat(beat,0);
+         axis_bus.write_beat(beat,0);
          payload_len = payload_len - 8;
       end
       beat = 64'h0;
       for (integer i=0; i < payload_len; i++) begin
          beat = (beat << 8) | this.get_payload_octet();
       end
-      axis_bus.push_beat(beat,1);
+      axis_bus.write_beat(beat,1);
     endtask // send_udp_to_ipv4_stream
 
 endclass : UDPPacket

--- a/lib/run_questa_gui_unit.sh
+++ b/lib/run_questa_gui_unit.sh
@@ -49,7 +49,7 @@ echo "runSVUnit"
 #    -voptargs=+acc=npr causes internal nodes to not be eliminated in optimization
 #    -permit_unmatched_virtual_intf solves a problem with virtual interfaces not matching any real interface
 #
-runSVUnit -s questa --c_arg "-incdir ../../global -incdir ../../axis +libext+.sv -y ../../axis -y ../../dsp -y ../../ethernet" \
-        --r_arg "-gui -voptargs=+acc=npr" -f dependencies.f -o sim $UNIT
+runSVUnit -s questa --c_arg "-incdir ../../global -incdir ../../axis -incdir ../../ethernet +libext+.sv -y ../../axis -y ../../dsp -y ../../ethernet" \
+        --r_arg "-gui -permit_unmatched_virtual_intf -voptargs=+acc=npr" -f dependencies.f -o sim $UNIT
 if [ $? -ne 0 ]; then exit 1 ; fi
 popd # 2>&1 > /dev/null

--- a/lib/run_questa_unit.sh
+++ b/lib/run_questa_unit.sh
@@ -49,7 +49,7 @@ echo "runSVUnit"
 #    -voptargs=+acc=npr causes internal nodes to not be eliminated in optimization
 #    -permit_unmatched_virtual_intf solves a problem with virtual interfaces not matching any real interface
 #
-runSVUnit -s questa --c_arg "-incdir ../../global -incdir ../../axis +libext+.sv -y ../../axis -y ../../dsp -y ../../ethernet" \
+runSVUnit -s questa --c_arg "-incdir ../../global -incdir ../../axis -incdir ../../ethernet +libext+.sv -y ../../axis -y ../../dsp -y ../../ethernet" \
           --r_arg "-permit_unmatched_virtual_intf" -f dependencies.f -o sim $UNIT
 if [ $? -ne 0 ]; then exit 1 ; fi
 popd # 2>&1 > /dev/null


### PR DESCRIPTION
Expand drat2eth_framer to have 8 discrete FlowID matches that map to unique UDP dst ports.
Changed to use common UDP src port to reduce unneeded CSRs

Also includes new block axis_ipv4_packet_fifo, an IPv4 aware FIFO that discards ingressing packets if there is not enough available space to buffer them. This is designed for rate control mechanisms.