### PR TITLE
axis_flow_control_time: fix backpressure bug

### DIFF
--- a/lib/axis/axis_flow_control_time.sv
+++ b/lib/axis/axis_flow_control_time.sv
@@ -179,10 +179,10 @@ module axis_flow_control_time
 
    always_comb begin
       unique case(state)
-        S_HEAD_IN: axis_fifo.tready <= 1'b1;
-        S_TIME_IN: axis_fifo.tready <= 1'b1;
-        S_PAYLOAD: axis_fifo.tready <= 1'b1;
-        default: axis_fifo.tready <= 1'b0;
+        S_HEAD_IN: axis_fifo.tready = 1'b1;
+        S_TIME_IN: axis_fifo.tready = 1'b1;
+        S_PAYLOAD: axis_fifo.tready = axis_out.tready;
+        default: axis_fifo.tready = 1'b0;
       endcase // unique case (state)
    end
 


### PR DESCRIPTION
The axis_flow_control_time isn't using the output TREADY to drive the internal FIFO TREADY. This causes beats from the FIFO to disappear if downstream applies backpressure.

This fixes the bug and also changes `<=` into `=` in the always_comb block.