### PR TITLE
Ian/add more udp ports

### DIFF
--- a/lib/ethernet/drat2eth_framer.sv
+++ b/lib/ethernet/drat2eth_framer.sv
@@ -171,7 +171,7 @@ module drat2eth_framer
       // UDP Source is always the same.
       udp_src = csr_udp_src;
       // if FlowID.dst[8] is set we use direct DRat->UDP port map mode.
-      if (drat_header.flow_id[8]) begin
+      if (drat_header.flow_id[8] == 1) begin
          // Direct Map FlowID.dst[5:0] to UDP Port LSBs.
          // csr_udp_dst8 sets 10MSB's of UDP port
          udp_dst = {csr_udp_dst8,drat_header.flow_id[5:0]};


### PR DESCRIPTION
Adds second block of contiguous UDP ports to Framer with a single base UDP port to index off.

To map a DRaT packet to this new UDP encapsulation, FlowID[8] must be set, which causes the UDP dest port to use the UDP base port as the upper 10bits, and  FlowID[5:0] as the LSB's.

The new base port is defined using `csr_udp_dst8`