### PR TITLE
Add BRAM register to axis_fifo_xilinx_bram and ram_dual_port_2clk

### DIFF
--- a/lib/dsp/dsp_rx.sv
+++ b/lib/dsp/dsp_rx.sv
@@ -60,7 +60,6 @@ module dsp_rx
    // using DRaT as the encapsulation.
    //
    //-------------------------------------------------------------------------------
-   axis_t #(.WIDTH(64)) axis_rx_packet_pre_fifo(.clk(clk));
   
    axis_stream_to_pkt_backpressured
      #(
@@ -92,20 +91,8 @@ module dsp_rx
       //-------------------------------------------------------------------------------
       // AXIS Output Bus
       //-------------------------------------------------------------------------------
-      .axis_pkt(axis_rx_packet_pre_fifo)
+      .axis_pkt(axis_rx_packet)
       );
-
-   // Breaks all combinatorial timing paths, helps with timing closure.
-   axis_minimal_fifo_wrapper framer_fifo_i0
-     (
-      .clk(clk),
-      .rst(rst),
-      .in_axis(axis_rx_packet_pre_fifo),
-      .out_axis(axis_rx_packet),
-	     .space_out(),
-      .occupied_out()
-      );
-
 
     //-------------------------------------------------------------------------------
    // Debug Only below

--- a/lib/misc/ram_dual_port_2clk.sv
+++ b/lib/misc/ram_dual_port_2clk.sv
@@ -6,6 +6,7 @@
 // Parameterizable:
 // * Width of datapath.
 // * Size (Depth) of RAM
+// * Usage of output register.
 //
 // Description:
 // Infer dual port, two clock synchronous SRAM.
@@ -15,29 +16,51 @@
 //-------------------------------------------------------------------------------
 `include "global_defs.svh"
 
+`default_nettype none
+
 module ram_dual_port_2clk
   #(
     parameter WIDTH=32,
     parameter SIZE=9, // Xilinx BRAM is 512x36
-    parameter ULTRA=0
-    ) 
+    parameter ULTRA=0,
+    parameter OUTPUT_REGISTER=0
+    )
    (
-    input logic             clk1,
-    input logic             enable1,
-    input logic             write1,
-    input logic [SIZE-1:0]  addr1,
-    input logic [WIDTH-1:0] data_in1,
-    output reg [WIDTH-1:0]  data_out1,
-   
-    input logic             clk2,
-    input logic             enable2,
-    input logic             write2,
-    input logic [SIZE-1:0]  addr2,
-    input logic [WIDTH-1:0] data_in2,
-    output reg [WIDTH-1:0]  data_out2
+    input wire               clk1,
+    input wire               enable1,
+    input wire               write1,
+    input wire [SIZE-1:0]    addr1,
+    input wire [WIDTH-1:0]   data_in1,
+    output logic [WIDTH-1:0] data_out1,
+
+    input wire               clk2,
+    input wire               enable2,
+    input wire               write2,
+    input wire [SIZE-1:0]    addr2,
+    input wire [WIDTH-1:0]   data_in2,
+    output logic [WIDTH-1:0] data_out2
     );
-   
+
    localparam               RAMSIZE = 1 << SIZE;
+
+   logic [WIDTH-1:0]        dout1;
+   logic [WIDTH-1:0]        dout2;
+
+   if (OUTPUT_REGISTER) begin: output_register
+      always_ff @(posedge clk1) begin
+         if (enable1) data_out1 <= dout1;
+      end
+
+      always_ff @(posedge clk2) begin
+         if (enable2) data_out2 <= dout2;
+      end
+   end: output_register
+   else begin: no_output_register
+      always_comb begin
+         data_out1 = dout1;
+         data_out2 = dout2;
+      end
+   end: no_output_register
 
    if (ULTRA == 1) begin: ultra
       (* ram_style = "ultra" *)  reg [WIDTH-1:0] ram [RAMSIZE-1:0];
@@ -49,7 +72,7 @@ module ram_dual_port_2clk
            begin
               if (write1)
                 ram[addr1] <= data_in1;
-              data_out1 <= ram[addr1];
+              dout1 <= ram[addr1];
            end
       end
 
@@ -61,7 +84,7 @@ module ram_dual_port_2clk
            begin
               if (write2)
                 ram[addr2] <= data_in2;
-              data_out2 <= ram[addr2];
+              dout2 <= ram[addr2];
            end
       end
    end: ultra
@@ -77,7 +100,7 @@ module ram_dual_port_2clk
              begin
                 if (write1)
                   ram[addr1] <= data_in1;
-                data_out1 <= ram[addr1];
+                dout1 <= ram[addr1];
              end
         end
 
@@ -89,8 +112,10 @@ module ram_dual_port_2clk
              begin
                 if (write2)
                   ram[addr2] <= data_in2;
-                data_out2 <= ram[addr2];
+                dout2 <= ram[addr2];
              end
         end
      end: normal
 endmodule // ram_dual_port_2clk
+
+`default_nettype wire


### PR DESCRIPTION
This adds a parameter to enable the output register of the BRAM defined in ram_dual_port_2clk. This is used by default in the AXI-S BRAM FIFO to improve timing.

The read logic in axis_fifo_xilinx_bram has been rewritten because it didn't seem to be easy to generalize to a read latency greater than 1 cycle.

Additionally, some SystemVerilog coding style improvements have been done in the two modified modules.