### PR TITLE
mux: fix bug caused by single-beat packets in port 0

### DIFF
--- a/lib/axis/axis_mux2.sv
+++ b/lib/axis/axis_mux2.sv
@@ -116,7 +116,10 @@ module axis_mux2
        case (arb_state)
          IDLE :
            if(in0_tvalid)
-             arb_state <= SELECT0;
+             // Go to SELECT0 state unless this is a single-beat packet whose
+             // beat is accepted in this cycle (when state is IDLE,
+             // in0_tready = in_tready).
+             arb_state <= in_tready && in0_tlast ? IDLE : SELECT0;
            else if(in1_tvalid)
              arb_state <= SELECT1;
 

--- a/lib/axis/axis_mux4.sv
+++ b/lib/axis/axis_mux4.sv
@@ -157,7 +157,10 @@ module axis_mux4
        case (arb_state)
          IDLE :
            if(in0_tvalid)
-             arb_state <= SELECT0;
+             // Go to SELECT0 state unless this is a single-beat packet whose
+             // beat is accepted in this cycle (when state is IDLE,
+             // in0_tready = in_tready).
+             arb_state <= in_tready && in0_tlast ? IDLE : SELECT0;
            else if(in1_tvalid)
              arb_state <= SELECT1;
            else if(in2_tvalid)

--- a/lib/axis/axis_mux8.sv
+++ b/lib/axis/axis_mux8.sv
@@ -219,7 +219,10 @@ module axis_mux8
        case (arb_state)
          IDLE : begin
             if(in0_tvalid)
-              arb_state <= SELECT0;
+              // Go to SELECT0 state unless this is a single-beat packet whose
+              // beat is accepted in this cycle (when state is IDLE,
+              // in0_tready = in_tready).
+              arb_state <= in_tready && in0_tlast ? IDLE : SELECT0;
             else if(in1_tvalid)
               arb_state <= SELECT1;
             else if(in2_tvalid)


### PR DESCRIPTION
If the mux is in IDLE state, its internal minimal_fifo is not full and a single-beat packet comes in port 0, the mux would remain in state SELECT0 instead of IDLE after forwarding this packet. This would prevent packets in other ports from being forwarded until a new packet comes in port 0.

The cause of the bug is that in IDLE, the mux acts similarly to the SELECT0 state: the input 0 is connected to the minimal_fifo and the other inputs have TREADY set to 0. Therefore, a single-beat packet in input 0 is completely processed in a single cycle in the IDLE state if the minimal_fifo is not full. The state machine needs to take this into account and remain in the IDLE state instead of going to SELECT0 when this happens.

The problem only happens in the first input, because if a packet comes in one of the other inputs (say input 1), first a cycle needs to be spent going from IDLE to SELECT1, and then from SELECT1 the state machine will go to IDLE whenever TLAST happens.

This commit fixes this bug in axis_mux2, axis_mux4 and axis_mux8.