### PR TITLE
Add explicit clk types

### DIFF
--- a/lib/axis/axis.sv
+++ b/lib/axis/axis.sv
@@ -21,7 +21,7 @@
 
 interface axis_t
   #(parameter WIDTH = 64)
-   (input clk);
+   (input wire clk);
    // Control flags
    bit                has_checks = 1;
 
@@ -142,7 +142,7 @@ endinterface : axis_t
 
 interface axis_user_t
   #(parameter WIDTH = 64, USER_WIDTH=4)
-   (input clk);
+   (input wire clk);
    // Control flags
    bit                has_checks = 1;
 
@@ -270,7 +270,7 @@ endinterface : axis_user_t
 //---------------------------------------------------------------------------------
 interface axis_slave_t
   #(parameter WIDTH = 64)
-   (input clk);
+   (input wire clk);
    // Control flags
    bit                has_checks = 1;
 
@@ -330,7 +330,7 @@ endinterface : axis_slave_t
 
 interface axis_master_t
   #(parameter WIDTH = 64)
-   (input clk);
+   (input wire clk);
    // Control flags
    bit                has_checks = 1;
 
@@ -383,7 +383,7 @@ endinterface : axis_master_t
 
 interface axis_broadcast_t
   #(parameter WIDTH = 64)
-   (input clk);
+   (input wire clk);
 
    //Actual Signals
    logic [WIDTH-1:0]  tdata;

--- a/lib/ethernet/ethernet.sv
+++ b/lib/ethernet/ethernet.sv
@@ -859,7 +859,7 @@ endpackage // ethernet_protocol
 //--   flag[3] may be set in lieu of an asserted TLAST or both may be asserted.
 //-- flags are nominally TUSER bits but are concatonated as TDATA[67:64] for ease of use with axis_t
 //-------------------------------------------------------------------------------
-interface eth_stream_t (input clk);
+interface eth_stream_t (input wire clk);
    import ethernet_protocol::*;
    axis_t #(.WIDTH(68)) axis (.clk(clk));
 


### PR DESCRIPTION
When being called from modules with default_nettype none the 
lack of an explicit type for interface clks throws an error.
Explicitly define all the interface clock ports as wire.