### PR TITLE
drat_protocol: add EOB types for float types

### DIFF
--- a/lib/global/drat_protocol.sv
+++ b/lib/global/drat_protocol.sv
@@ -50,8 +50,12 @@ typedef enum logic [7:0]
    //  INT12_REAL,
    // Float complex numbers in an IEEE 32bit format. Used for example for IQ sample data
    FLOAT32_COMPLEX=8'h02,
+   // Float complex numbers in an IEEE 32bit format. Marks end of burst.
+   FLOAT32_COMPLEX_EOB=8'h12,
    // Float real numbers in an IEEE 32bit format. Used for example for IQ sample data
    FLOAT32_REAL=8'h03,
+   // Float real numbers in an IEEE 32bit format. Marks end of burst.
+   FLOAT32_REAL_EOB=8'h13,
    // Integer complex numbers in a 16 vectors of 16bit format.
    INT16x16_COMPLEX=8'h08,
    // Integer complex numbers in a 16 vectors of 16bit format. Marks end of burst.


### PR DESCRIPTION
I've just realized that that the float EOB types that were added by #25 were deleted by #26, so I'm sending this PR to add these types again.