### PR TITLE
axis_stream_to_pkt_backpressured: fix enable and fifos_reset bug

### DIFF
--- a/lib/axis/axis_stream_to_pkt_backpressured.sv
+++ b/lib/axis/axis_stream_to_pkt_backpressured.sv
@@ -439,8 +439,12 @@ module axis_stream_to_pkt_backpressured
    end // always_ff @ (posedge clk)
 
    always_ff @(posedge clk) begin
-      // this register does not need a reset
-      fifos_reset <= output_state == S_FIFO_RESET;      
+      // This register does not need a reset
+      //
+      // !enable used here to release the reset one cycle earlier. This is
+      // needed to avoid losing data on enable due to the FIFO being reset while
+      // the first samples beat is written.
+      fifos_reset <= (output_state == S_FIFO_RESET) && !enable;
    end
 
    //


### PR DESCRIPTION
This fixes a bug that was introduced with the addition of the `fifos_reset` signal, which causes the internal FIFOs to be reset so that stale samples are dropped when the module is disabled.

The bug is that when enable is asserted, `fifos_reset` takes 2 clock cycles to deassert, because first output_state must change to `S_OUTPUT_HEADER`, and then the `fifos_reset` flip-flop must update to 0. If samples are available at the input every clock cycle, then the first clock cycle the input state machine is in `S_IDLE` and accepts one input sample, passing to `S_INPUT_PHASE_2`. The second clock cycle, a new input sample is accepted and the two samples are attempted to be written to the `sample_fifo`. However this FIFO is still in reset, so it discards the write. This causes a mismatch between the `input_count` (since both samples have been counted) and the number of samples in `sample_fifo`.

To fix this bug, `&& !enable` is added to the input of the `fifos_reset`, flip-flop. This causes `fifos_reset+  to go low one cycle earlier, so no data is lost.

---

The `axis_stream_to_pkt_backpressured_unit_test.sv` tests didn't catch this error because in all of the the input TVALID goes high after `enable` has already gone high.

The following traces from a simulation in which the input TVALID is always high and the input TDATA is a 32-bit counter show the problem.

This is without the fix. Note that the first write into the `sample_fifo` is lost because `rst` is still asserted.
![without_fix](https://github.com/user-attachments/assets/4594bd6a-f98f-49c9-9335-e4a8d71f7db8)

This is with this fix. The first write is accepted by `sample_fifo`, because `rst` has become low in this clock cycle.
![with_fix](https://github.com/user-attachments/assets/9ecaaacd-3454-4994-9d9d-2a8373de99ae)
