### PR TITLE
dsp_rx: add TIME_PER_PKT_WIDTH parameter

### DIFF
--- a/lib/axis/axis_stream_to_pkt_backpressured.sv
+++ b/lib/axis/axis_stream_to_pkt_backpressured.sv
@@ -43,7 +43,9 @@ module axis_stream_to_pkt_backpressured
     // Packet FIFO has 2**PACKET_FIFO_SIZE entries
     parameter PACKET_FIFO_SIZE=8,
     // Width of IQ samples from Datapath. If <16b then samples MSB justified into packets.
-    parameter IQ_WIDTH=16
+    parameter IQ_WIDTH=16,
+    // Width of time_per_pkt CSR field
+    parameter TIME_PER_PKT_WIDTH=16
     )
 
    (
@@ -54,7 +56,7 @@ module axis_stream_to_pkt_backpressured
     input logic [63:0] start_time, // Write this register with start time to annotate into bursts first packet.
     input logic [13:0] packet_size, // Packet size expressed in number of samples
     input logic [31:0] flow_id, // DRaT Flow ID for this flow (union of src + dst)
-    input logic [15:0] time_per_pkt, // Time increment per packet of size packet_size
+    input logic [TIME_PER_PKT_WIDTH-1:0] time_per_pkt, // Time increment per packet of size packet_size
     input logic [47:0] burst_size, // Number of samples in a burst. Write to zero for infinite burst.
     input logic        abort, // Assert this signal for a single cycle to trigger an async return to idle.
     // Status Flags

--- a/lib/dsp/dsp_rx.sv
+++ b/lib/dsp/dsp_rx.sv
@@ -19,7 +19,8 @@ module dsp_rx
     parameter RX_TIME_FIFO_SIZE = 4,  // Default from axis_stream_to_pkt_wrapper
     parameter RX_SAMPLE_FIFO_SIZE = 12,  // Default from axis_stream_to_pkt_wrapper
     parameter RX_PACKET_FIFO_SIZE = 9,  // Default from axis_stream_to_pkt_wrapper
-    parameter IQ_WIDTH = 16  // Default from axis_stream_to_pkt_wrapper
+    parameter IQ_WIDTH = 16,  // Default from axis_stream_to_pkt_wrapper
+    parameter TIME_PER_PKT_WIDTH=16  // Default from axis_stream_to_pkt_wrapper
     )
    (
     input logic        clk,
@@ -34,7 +35,7 @@ module dsp_rx
     // DRaT Flow ID for this flow (union of src + dst)
     input logic [31:0] csr_rx_flow_id,
     // Time increment per packet of size packet_size
-    input logic [15:0] csr_rx_time_per_pkt,
+    input logic [TIME_PER_PKT_WIDTH-1:0] csr_rx_time_per_pkt,
     // Number of samples in a burst. Write to zero for infinite burst.
     input logic [47:0] csr_rx_burst_size,
     // Assert this signal for a single cycle to trigger an async return to idle.
@@ -66,7 +67,8 @@ module dsp_rx
        .TIME_FIFO_SIZE(RX_TIME_FIFO_SIZE),
        .SAMPLE_FIFO_SIZE(RX_SAMPLE_FIFO_SIZE),
        .PACKET_FIFO_SIZE(RX_PACKET_FIFO_SIZE),
-       .IQ_WIDTH(IQ_WIDTH)
+       .IQ_WIDTH(IQ_WIDTH),
+       .TIME_PER_PKT_WIDTH(TIME_PER_PKT_WIDTH)
        )
    axis_stream_to_pkt_backpressured_i0
      (


### PR DESCRIPTION
This adds a `TIME_PER_PKT_WIDTH` parameter that allows changing the size of the CSR `time_per_pkt` field. It defaults to 16, which is what the previous code used. The rationale is that at high decimation factors (which imply a large ticks/sample value) with 2048 samples/packet (jumbo frames), 16 bits is not enough.

---

**Testing done**

Codebase using DiRT builds and works fine after using this change to increase the width beyond 16 bits.