### PR TITLE
Add bus wide differential buffers

### DIFF
--- a/lib/io/Makefile.srcs
+++ b/lib/io/Makefile.srcs
@@ -10,5 +10,7 @@
 #-----------------------------------------------------------------------------
 
 DIRT_IO_SRCS = $(abspath $(addprefix $(DIRT_DIR)/lib/io/, \
-dirt_io_buf.sv \
+dirt_iobuf.sv \
+dirt_ibufds.sv \
+dirt_obufds.sv \
 ))

--- a/lib/io/dirt_ibufds.sv
+++ b/lib/io/dirt_ibufds.sv
@@ -1,5 +1,5 @@
 //-----------------------------------------------------------------------------
-// File:   dirt_io_buf.sv
+// File:   dirt_ibufds.sv
 //
 // Author:  Ian Buckley, Ion Concepts LLC.
 //
@@ -7,7 +7,7 @@
 // * Width of datapath.
 //
 // Description:
-// Instantiates bus of Xilinx IO_BUF
+// Instantiates bus of Xilinx IBUFDS
 //
 //
 // License: CERN-OHL-P (See LICENSE.md)
@@ -16,29 +16,33 @@
 `default_nettype none
 `timescale 1ns/1ps
 
-module dirt_io_buf
+module dirt_ibufds
   #(
-    parameter WIDTH = 1
+    parameter WIDTH = 1,
+    parameter DIFF_TERM = "TRUE",
+    parameter IBUF_LOW_PWR = "TRUE"
     )
    (
     input wire [WIDTH-1:0]  I,
-    input wire [WIDTH-1:0]  T, // Tristates output buffer when asserted HIGH.
-    inout wire [WIDTH-1:0]  IO,
-    output wire [WIDTH-1:0] O 
+    input wire [WIDTH-1:0]  IB,
+    output wire [WIDTH-1:0] O
     );
 
    genvar		     i;
    generate
       for (i=0; i < WIDTH; i++) begin
-	 IOBUF dirt_io_buf_i
+	 IBUFDS # (
+             .DIFF_TERM (DIFF_TERM),
+             .IBUF_LOW_PWR (IBUF_LOW_PWR)
+             )
+	     dirt_ibufds_i
 	     (
 	      .I(I[i]),
-	      .IO(IO[i]),
-	      .O(O[i]),
-	      .T(T[i])
+	      .IB(IB[i]),
+	      .O(O[i])
 	      );
       end
    endgenerate
 
 
-endmodule // dirt_io_buf
+endmodule // dirt_ibufds

--- a/lib/io/dirt_iobuf.sv
+++ b/lib/io/dirt_iobuf.sv
@@ -1,0 +1,44 @@
+//-----------------------------------------------------------------------------
+// File:   dirt_iobuf.sv
+//
+// Author:  Ian Buckley, Ion Concepts LLC.
+//
+// Parameterizable:
+// * Width of datapath.
+//
+// Description:
+// Instantiates bus of Xilinx IOBUF
+//
+//
+// License: CERN-OHL-P (See LICENSE.md)
+//
+//-----------------------------------------------------------------------------
+`default_nettype none
+`timescale 1ns/1ps
+
+module dirt_iobuf
+  #(
+    parameter WIDTH = 1
+    )
+   (
+    input wire [WIDTH-1:0]  I,
+    input wire [WIDTH-1:0]  T, // Tristates output buffer when asserted HIGH.
+    inout wire [WIDTH-1:0]  IO,
+    output wire [WIDTH-1:0] O 
+    );
+
+   genvar		     i;
+   generate
+      for (i=0; i < WIDTH; i++) begin
+	 IOBUF dirt_iobuf_i
+	     (
+	      .I(I[i]),
+	      .IO(IO[i]),
+	      .O(O[i]),
+	      .T(T[i])
+	      );
+      end
+   endgenerate
+
+
+endmodule // dirt_iobuf

--- a/lib/io/dirt_obufds.sv
+++ b/lib/io/dirt_obufds.sv
@@ -1,0 +1,42 @@
+//-----------------------------------------------------------------------------
+// File:   dirt_obufds.sv
+//
+// Author:  Ian Buckley, Ion Concepts LLC.
+//
+// Parameterizable:
+// * Width of datapath.
+//
+// Description:
+// Instantiates bus of Xilinx OBUFDS
+//
+//
+// License: CERN-OHL-P (See LICENSE.md)
+//
+//-----------------------------------------------------------------------------
+`default_nettype none
+`timescale 1ns/1ps
+
+module dirt_obufds
+  #(
+    parameter WIDTH = 1
+    )
+   (
+    input wire [WIDTH-1:0]  I,
+    output wire [WIDTH-1:0] O,
+    output wire [WIDTH-1:0] OB
+    );
+
+   genvar		     i;
+   generate
+      for (i=0; i < WIDTH; i++) begin
+	 OBUFDS dirt_obufds_i
+	     (
+	      .I(I[i]),
+	      .O(O[i]),
+	      .OB(OB[i])
+	      );
+      end
+   endgenerate
+
+
+endmodule // dirt_obufds


### PR DESCRIPTION
Adding bus wide differential buffers (OBUFDS,IBUFDS).
Tweaked name of IO buffer to match exact Xilinx name (IOBUF).
Built against a Xilinx target to test.
