### PR TITLE
Add .rdl files to support tx_dsp and rx_dsp etc

### DIFF
--- a/lib/axis/axis_time_report.rdl
+++ b/lib/axis/axis_time_report.rdl
@@ -24,7 +24,7 @@ regfile time_report {
 
   reg {
     name="control";
-    desc="FlowID for time report packets";
+    desc="Control Register";
     field {
       sw=rw;
       hw = r;

--- a/lib/axis/axis_time_report.rdl
+++ b/lib/axis/axis_time_report.rdl
@@ -1,0 +1,33 @@
+  //-------------------------------------------------------------------------------
+  // Time Report
+  //-------------------------------------------------------------------------------
+regfile time_report {
+  desc = "Time Report Registers";
+
+  reg {
+    name="period";
+    desc="Period between time report packets in 256 DSP clock ticks";
+    field {
+      sw=rw;
+      hw = r;
+    } period [15:0] = 0x0;
+  } period;
+
+  reg {
+    name="flowid";
+    desc="FlowID for time report packets";
+    field {
+      sw=rw;
+      hw = r;
+    } flowid [31:0] = 0x0;
+  } flowid;
+
+  reg {
+    name="control";
+    desc="FlowID for time report packets";
+    field {
+      sw=rw;
+      hw = r;
+    } enable [0:0] = 0x0;
+  } control;
+};

--- a/lib/dsp/dsp_rx.rdl
+++ b/lib/dsp/dsp_rx.rdl
@@ -1,0 +1,79 @@
+
+regfile dsp_rx {
+  desc = "RX DSP Registers";
+
+ 
+  //---------------------------------------
+  // axi_stream_to_pkt_backpressured
+  //---------------------------------------
+  reg {
+    name="rx_control";
+    desc="Controls operation of axi_stream_to_pkt_backpressured";
+    field {
+      sw=rw;
+      hw = r;
+      } far_loopback [31:31] = 0;
+    field {
+      sw=rw;
+      hw = r;
+    } rx_abort [1:1] = 0;
+    field {
+      sw=rw;
+      hw = r;
+    } stream_to_pkt_enable [0:0] = 0;
+  } rx_control;
+
+  reg {
+    name="rx_status";
+    desc="Status of axi_stream_to_pkt_backpressured";
+    field {
+      sw=r;
+      hw=w;
+    } idle;
+  } rx_status;
+
+  reg {
+    name="rx_packet_size";
+    desc="Number of samples to frame in a single packet";
+    field {
+      sw=rw;
+      hw = r;
+    } samples [13:0] = 0x0;
+  } rx_packet_size;
+
+  reg {
+    name="rx_flow_id";
+    desc="Sets FlowID for RX Packets";
+    field {
+      sw=rw;
+      hw = r;
+    } flow_id [31:0] = 0x0;
+  } rx_flow_id;
+
+  reg {
+    name="rx_time_per_pkt";
+    desc="Time increment per sucessive packet";
+    field {
+      sw=rw;
+      hw = r;
+    } time_per_pkt [15:0] = 0x0;
+  } rx_time_per_pkt;
+
+  reg {
+    name="rx_burst_size_upper";
+    desc="Upper 16bits of Length of burst (Zero for infinite)";
+    field {
+      sw=rw;
+      hw = r;
+    } size [15:0] = 0x0;
+  } rx_burst_size_upper;
+
+  reg {
+    name="rx_burst_size_lower";
+    desc="Lower 32bits of Length of burst (Zero for infinite)";
+    field {
+      sw=rw;
+      hw = r;
+    } size [31:0] = 0x0;
+  } rx_burst_size_lower;
+};

--- a/lib/dsp/dsp_tx.rdl
+++ b/lib/dsp/dsp_tx.rdl
@@ -1,0 +1,54 @@
+
+regfile dsp_tx {
+  desc = "TX DSP Registers";
+
+  //---------------------------------------
+  // axi_pkt_to_stream
+  //---------------------------------------
+  reg {
+    name="tx_control";
+    desc="Controls operation of axi_pkt_to_stream";
+    field {
+      sw=rw;
+      hw = r;
+      } consumption_period [15:8] = 0;
+    field {
+      sw=rw;
+      hw = r;
+    } tx_error_policy_next_packet [4:4] = 1;
+    field {
+      sw=rw;
+      hw = r;
+    } deframer_enable[3:3]  = 0;
+    field {
+      sw=rw;
+      hw = r;
+    } status_enable [2:2] = 0;
+    field {
+      sw=rw;
+      hw = r;
+    } consumption_enable [1:1]  = 0;
+    field {
+      sw=rw;
+      hw = r;
+    } tx_control_enable [0:0] = 0;
+  } tx_control;
+
+  reg {
+    name="tx_status_flow_id";
+    desc="Sets FlowID for Status Packets";
+    field {
+      sw=rw;
+      hw = r;
+    } flow_id [31:0] = 0x0;
+  } tx_status_flow_id;
+
+  reg {
+    name="tx_consumption_flow_id";
+    desc="Sets FlowID for Consumption Packets";
+    field {
+      sw=rw;
+      hw = r;
+    } flow_id [31:0] = 0x0;
+  } tx_consumption_flow_id;
+};


### PR DESCRIPTION
Add supporting .rdl files containing programming register definitions for the RX and TX DSP's as well as time reports.
This continues the trend of pulling standardized DiRT CSR definitions in from the project file system for better reuse.
No modifications to existing files so 100% safe for existing users.