### PR TITLE
Newest version of SystemRDL has quirk with register named udp, change…

### DIFF
--- a/lib/ethernet/classifier.rdl
+++ b/lib/ethernet/classifier.rdl
@@ -34,7 +34,7 @@ regfile classifier {
       name="";
       desc="";
     } ip [31:0] = 0x0;
-  } ip;
+  } ip0;
 
   reg {
     name="udp";
@@ -51,7 +51,7 @@ regfile classifier {
       name="";
       desc="";
     } udp_port1 [31:16] = 0x0;
-  } udp;
+  } udp0;
 
   reg {
     name="control";


### PR DESCRIPTION
Newest version of SystemRDL has quirk with register named "udp"
"udp" gets silently renamed to "register_udp".
Similar strings do not get changed.
No reference to this being a reserved word has been found, unclear if its a bug or intent.
Changed name to udp0 (And ip to ip0 for consistency).
This is a breaking change for RTL and python using this register.

Environment: 
```
(env) ianb@cruncher:~/swiftbeat/radio-fpga$ more requirements.txt
pipoe==2019.11
peakrdl==1.4.0
peakrdl-cli==1.4.0
peakrdl-halcpp==0.4.1
peakrdl-html==2.11.0
peakrdl-ipxact==3.5.0
peakrdl_markdown==1.0.2
peakrdl-python==0.9.3
peakrdl-regblock==1.1.0
peakrdl-systemrdl==1.0.0
peakrdl-uvm==2.3.0
systemrdl-compiler==1.29.3
```