### PR TITLE
Add generic gemac port built around Xilinx PCS/PMA (.xci Not included)

### DIFF
--- a/lib/ethernet/Makefile.srcs
+++ b/lib/ethernet/Makefile.srcs
@@ -12,6 +12,9 @@
 DIRT_ETHERNET_SRCS = $(abspath $(addprefix $(DIRT_DIR)/lib/ethernet/, \
 drat2eth_framer.sv \
 eth_classifier_2_egress.sv \
+eth_pcs_pma_1g_wrapper.sv \
 eth_router_3_port.sv \
 ethernet.sv \
+gemac_wrapper.sv \
+port_1000basex.sv \
 ))

--- a/lib/ethernet/eth_pcs_pma_1g_wrapper.sv
+++ b/lib/ethernet/eth_pcs_pma_1g_wrapper.sv
@@ -1,0 +1,196 @@
+//-------------------------------------------------------------------------------
+// File:    eth_pcs_pma_1g_wrapper.sv
+//
+// Copyright:  Ian Buckley, Ion Concepts LLC.
+//
+// Description:
+// Wraps Xilinx 1G Ethernet PCS PMA.
+//
+// License: CERN-OHL-P (See LICENSE.md)
+//
+//-------------------------------------------------------------------------------
+`include "global_defs.svh"
+
+module eth_pcs_pma_1g_wrapper
+  #(
+        parameter XILINX_CLOCKING=1
+    )
+   (
+    input wire		clk,
+    input wire		reset,
+    output logic	clk_125,
+    // This clock can be between 6.26MHz and 62.5MHz for Ultarscale+ (See PG047 for details)
+    input wire		independent_clock_bufg,
+    //-------------------------------------------------------------------------------
+    // CSR registers
+    //-------------------------------------------------------------------------------
+    input logic [31:0]	gmii_ctl,
+    output logic [31:0]	gmii_stat,
+    //-------------------------------------------------------------------------------
+    // MDIO Interface
+    //-------------------------------------------------------------------------------
+    mdio_t.phy phy_mdio,
+    //-------------------------------------------------------------------------------
+    // GMII Interface
+    //-------------------------------------------------------------------------------
+    output logic	gmii_reset,
+    gmii_t.xilinx_phy phy_gmii,
+    //-------------------------------------------------------------------------------
+    // Transceiver package pins
+    //-------------------------------------------------------------------------------
+    input logic		rxp,
+    input logic		rxn,
+    output logic	txp,
+    output logic	txn,
+    input logic		gtrefclk_p,
+    input logic		gtrefclk_n
+    );
+
+   logic [63:0]         mdio_data;
+   logic [5:0]          mdio_clk_cnt;
+   logic [6:0]          mdio_bit_cnt;
+   wire                 reset_x;
+
+   wire                 gtrefclk_out;
+   wire                 userclk_out;
+   wire                 userclk2_out;
+   wire                 rxuserclk_out;
+   wire                 rxuserclk2_out;
+   wire                 gtpowergood;
+   wire                 resetdone;
+   wire                 pma_reset_out;
+   wire                 mmcm_locked_out;
+   wire                 gmii_isolate;
+   logic [4:0]          phyaddr;
+   logic [4:0]          configuration_vector;
+   logic                configuration_valid_reg;
+   logic                configuration_valid;
+   wire [15:0]          status_vector;
+   logic                reset_csr;
+   logic                signal_detect;
+
+   always_comb begin
+      gmii_stat[0] = gtpowergood;
+      gmii_stat[1] = resetdone;
+      gmii_stat[2] = pma_reset_out;
+      gmii_stat[3] = mmcm_locked_out;
+      gmii_stat[4] = gmii_isolate;
+      gmii_stat[15:5] = 11'h0; // Unused
+      gmii_stat[31:16] = status_vector[15:0];
+   end
+
+   always_comb begin
+      reset_csr = gmii_ctl[0];
+      signal_detect = ~gmii_ctl[1];
+      configuration_valid = gmii_ctl[2];
+      configuration_vector = gmii_ctl[7:3];
+      phyaddr = 5'b0;
+      // Always full duplex ethernet, no CSMA-CD
+      phy_gmii.col = 1'b0;
+      phy_gmii.cs = 1'b0;
+   end
+
+   always_comb
+     clk_125 = userclk2_out;
+   
+
+   //-------------------------------------------------------------------------------
+   // Xilinx IP - LogiCORE IP Ethernet 1000BASE-X PCS/PMA (DS264)
+   //-------------------------------------------------------------------------------
+   generate
+      if (XILINX_CLOCKING == 1) begin
+         eth_pcs_pma_1g eth_pcs_pma_1g_i0
+           (
+            .gtrefclk_p(gtrefclk_p),
+            .gtrefclk_n(gtrefclk_n),
+            .gtrefclk_out(gtrefclk_out),
+            .txn(txn),
+            .txp(txp),
+            .rxn(rxn),
+            .rxp(rxp),
+            .independent_clock_bufg(independent_clock_bufg),
+            .userclk_out(userclk_out),
+            .userclk2_out(userclk2_out),
+            .rxuserclk_out(rxuserclk_out),
+            .rxuserclk2_out(rxuserclk2_out),
+            .gtpowergood(gtpowergood),
+            .resetdone(resetdone),
+            .pma_reset_out(pma_reset_out),
+            .mmcm_locked_out(mmcm_locked_out),
+            .gmii_txclk(phy_gmii.txclk),
+            .gmii_rxclk(phy_gmii.rxclk),
+            .gmii_txd(phy_gmii.txd),
+            .gmii_tx_en(phy_gmii.txen),
+            .gmii_tx_er(phy_gmii.txer),
+            .gmii_rxd(phy_gmii.rxd),
+            .gmii_rx_dv(phy_gmii.rxdv),
+            .gmii_rx_er(phy_gmii.rxer),
+            .gmii_isolate(gmii_isolate),
+            .mdc(phy_mdio.mdc),
+            .mdio_i(phy_mdio.mdo),
+            .mdio_o(phy_mdio.mdi),
+            .mdio_t(), // Unused
+            .phyaddr(phyaddr),
+            .configuration_vector(configuration_vector),
+            .configuration_valid(configuration_valid_reg),
+            .status_vector(status_vector),
+            .reset(reset_csr),
+            .signal_detect(signal_detect)
+            );
+      end else if (XILINX_CLOCKING == 0) begin // if (XILINX_CLOCKING == 1)
+         eth_pcs_pma_1g eth_pcs_pma_1g_i0
+           (
+            .gtrefclk_p(gtrefclk_p),
+            .gtrefclk_n(gtrefclk_n),
+            .gtrefclk_out(gtrefclk_out),
+            .txn(txn),
+            .txp(txp),
+            .rxn(rxn),
+            .rxp(rxp),
+            .independent_clock_bufg(independent_clock_bufg),
+            .userclk_out(userclk_out),
+            .userclk2_out(userclk2_out),
+            .rxuserclk_out(rxuserclk_out),
+            .rxuserclk2_out(rxuserclk2_out),
+            .gtpowergood(gtpowergood),
+            .resetdone(resetdone),
+            .pma_reset_out(pma_reset_out),
+            .mmcm_locked_out(mmcm_locked_out),
+            .gmii_txclk(), // No connect to prevent multiple driver issues
+            .gmii_rxclk(phy_gmii.rxclk),
+            .gmii_txd(phy_gmii.txd),
+            .gmii_tx_en(phy_gmii.txen),
+            .gmii_tx_er(phy_gmii.txer),
+            .gmii_rxd(phy_gmii.rxd),
+            .gmii_rx_dv(phy_gmii.rxdv),
+            .gmii_rx_er(phy_gmii.rxer),
+            .gmii_isolate(gmii_isolate),
+            .mdc(phy_mdio.mdc),
+            .mdio_i(phy_mdio.mdo),
+            .mdio_o(phy_mdio.mdi),
+            .mdio_t(), // Unused
+            .phyaddr(phyaddr),
+            .configuration_vector(configuration_vector),
+            .configuration_valid(configuration_valid_reg),
+            .status_vector(status_vector),
+            .reset(reset_csr),
+            .signal_detect(signal_detect)
+            );
+      end
+   endgenerate
+
+
+   assign  gmii_reset = ~resetdone;
+
+   //-------------------------------------------------------------------------------
+   // FIXME! - Unprotected clock domain crossing
+   //-------------------------------------------------------------------------------
+   logic send_config;
+   
+   always_ff @(posedge userclk2_out) 
+     begin
+        send_config  <= resetdone;
+        configuration_valid_reg <= (gmii_isolate && send_config) || configuration_valid;
+     end
+
+endmodule

--- a/lib/ethernet/gemac_wrapper.sv
+++ b/lib/ethernet/gemac_wrapper.sv
@@ -1,0 +1,288 @@
+//-----------------------------------------------------------------------------
+// File:   gemac_wrapper.sv
+//
+// Author:  Ian Buckley, Ion Concepts LLC.
+//
+// Description:
+//   Wrap Ettus 1G ethernet MAC with DiRT interfaces
+//   Translate 68bit AXIS Ethernet interface to MAC 8bit interfaces
+//-----------------------------------------------------------------------------
+`default_nettype none
+
+module gemac_wrapper
+  #(
+    parameter RX_FLOW_CTRL=0,
+    parameter PORTNUM=8'd0
+    )
+   (
+    input wire  clk,
+    input wire  clk125,
+    input wire  rst,
+    //-------------------------------------------------------------------------------
+    // GMII Interface
+    //-------------------------------------------------------------------------------
+    output logic gmii_reset,
+    gmii_t.mac mac_gmii, // Legal GMII, true source synchronous
+    //-------------------------------------------------------------------------------
+    // AXIS interfaces
+    //-------------------------------------------------------------------------------
+    axis_t.slave in_axis,
+    axis_t.master out_axis
+    );
+
+   localparam           PAUSE_RESPECT_EN = 1'b0;
+   localparam           PAUSE_REQUEST_EN = 1'b0;
+
+   // Exploded in_axis bus
+   logic [63:0]         rx_tdata;
+   logic                rx_tvalid;
+   logic                rx_tready;
+   logic                rx_tlast;
+   logic [3:0]          rx_tuser;
+
+   // Exploded out_axis bus
+   logic [63:0]         tx_tdata;
+   logic                tx_tvalid;
+   logic                tx_tready;
+   logic                tx_tlast;
+   logic [3:0]          tx_tuser;
+
+   // 8bit RX interface to MAC	
+   logic [7:0]          rx_data;
+   logic                rx_valid;
+   logic                rx_error;
+   logic                rx_ack;
+
+   // 8bit TX interface to MAC
+   logic [7:0]          tx_data;
+   logic                tx_valid;
+   logic                tx_error;
+   logic                tx_ack;
+
+   logic                tx_reset;
+   logic                rx_reset;
+   logic                pause_req;
+   logic                pause_request_en;
+   logic [15:0]         pause_time, pause_thresh, pause_time_req, rx_fifo_space;
+
+   synchronizer #(.FALSE_PATH_TO_IN(1),.INITIAL_VAL(1),.STAGES(2)) reset_sync_tx
+     (.clk(mac_gmii.txclk),.rst(1'b0),.in(rst),.out(tx_reset));
+   synchronizer #(.FALSE_PATH_TO_IN(1),.INITIAL_VAL(1),.STAGES(2)) reset_sync_rx
+     (.clk(mac_gmii.rxclk),.rst(1'b0),.in(rst),.out(rx_reset));
+
+   //-------------------------------------------------------------------------------
+   // Ettus 1G MAC
+   //-------------------------------------------------------------------------------
+
+   simple_gemac simple_gemac_i0
+     (
+      .clk125(clk125),
+      .reset(rst),
+      // GMII interface
+      .GMII_GTX_CLK(mac_gmii.txclk), // OUTPUT, legal GMII
+      .GMII_TX_EN(mac_gmii.txen),
+      .GMII_TX_ER(mac_gmii.txer),
+      .GMII_TXD(mac_gmii.txd),
+      .GMII_RX_CLK(mac_gmii.rxclk),
+      .GMII_RX_DV(mac_gmii.rxdv),
+      .GMII_RX_ER(mac_gmii.rxer),
+      .GMII_RXD(mac_gmii.rxd),
+      // Pause frame interface
+      .pause_req(RX_FLOW_CTRL ? pause_req : 1'b0),
+      .pause_time_req(RX_FLOW_CTRL ? pause_time_req : 16'd0),
+      .pause_respect_en(PAUSE_RESPECT_EN),
+      // unicast/broadcast/multicast address filtering
+      // (Set to be promisicious)
+      .ucast_addr(48'h0),
+      .mcast_addr(48'h0),
+      .pass_ucast(1'b0),
+      .pass_mcast(1'b0),
+      .pass_bcast(1'b0),
+      .pass_pause(1'b0),
+      .pass_all(1'b1),
+      // 8bit RX MAC interface
+      .rx_clk(), // Passes out mac_gmii.rxclk
+      .rx_data(rx_data),
+      .rx_valid(rx_valid),
+      .rx_error(rx_error),
+      .rx_ack(rx_ack),
+      // 8bit TX MAC interface
+      .tx_clk(mac_gmii.txclk),
+      .tx_data(tx_data),
+      .tx_valid(tx_valid),
+      .tx_error(tx_error),
+      .tx_ack(tx_ack),
+      .debug()
+      );
+
+   //-------------------------------------------------------------------------------
+   // RX: 8bit FIFO -> 68bit Ethernet AXIS
+   //-------------------------------------------------------------------------------
+   wire                 rx_ll_eof;
+   wire                 rx_ll_error;
+   wire                 rx_ll_src_rdy;
+   wire                 rx_ll_dst_rdy;
+   wire [7:0]           rx_ll_data;
+
+   wire [63:0]          rx_tdata_int;
+   wire [3:0]           rx_tuser_int;
+   wire                 rx_tlast_int;
+   wire                 rx_tvalid_int;
+   wire                 rx_tready_int;
+
+   rxmac_to_ll8 rxmac_to_ll8_i0
+     (
+      .clk(mac_gmii.rxclk),
+      .reset(rx_reset),
+      .clear(1'b0),
+      // RX MAC interface
+      .rx_data(rx_data),
+      .rx_valid(rx_valid),
+      .rx_error(rx_error),
+      .rx_ack(rx_ack),
+      // 8bit FIFO interface
+      .ll_data(rx_ll_data),
+      .ll_sof(),  // ignore sof
+      .ll_eof(rx_ll_eof),
+      .ll_error(rx_ll_error),
+      .ll_src_rdy(rx_ll_src_rdy),
+      .ll_dst_rdy(rx_ll_dst_rdy));
+
+   ll8_to_axi64 #(.START_BYTE(6), .LABEL(PORTNUM)) ll8_to_axi64_i0
+     (
+      .clk(mac_gmii.rxclk),
+      .reset(rx_reset),
+      .clear(1'b0),
+      // 8bit FIFO interface
+      .ll_data(rx_ll_data),
+      .ll_eof(rx_ll_eof),
+      .ll_error(rx_ll_error),
+      .ll_src_rdy(rx_ll_src_rdy),
+      .ll_dst_rdy(rx_ll_dst_rdy),
+      // 64bit+4bit AXIS
+      .axi64_tdata(rx_tdata_int),
+      .axi64_tlast(rx_tlast_int),
+      .axi64_tuser(rx_tuser_int),
+      .axi64_tvalid(rx_tvalid_int),
+      .axi64_tready(rx_tready_int));
+
+   axis_fifo_512x69_2clk axis_fifo_512x69_2clk_i0
+     (
+      .s_aresetn(~rx_reset), // Active low, Async
+      // Input
+      .s_aclk(mac_gmii.rxclk),
+      .s_axis_tvalid(rx_tvalid_int),
+      .s_axis_tready(rx_tready_int),
+      .s_axis_tdata(rx_tdata_int),
+      .s_axis_tuser(rx_tuser_int),
+      .s_axis_tlast(rx_tlast_int),
+      // Output
+      .m_aclk(clk),
+      .m_axis_tvalid(rx_tvalid),
+      .m_axis_tready(rx_tready),
+      .m_axis_tdata(rx_tdata),
+      .m_axis_tuser(rx_tuser),
+      .m_axis_tlast(rx_tlast)
+      );
+
+    always_comb begin
+        out_axis.tdata  = {rx_tuser,rx_tdata};
+        out_axis.tvalid = rx_tvalid;
+        out_axis.tlast  = rx_tlast;
+        rx_tready       = out_axis.tready;
+    end
+
+   //-------------------------------------------------------------------------------
+   // TX: 68bit Ethernet AXIS -> 8bit FIFO
+   //-------------------------------------------------------------------------------
+
+   wire 	  tx_ll_eof;
+   wire           tx_ll_src_rdy;
+   wire           tx_ll_dst_rdy;
+   wire [7:0]     tx_ll_data;
+
+   wire [63:0]    tx_tdata_int;
+   wire [3:0]     tx_tuser_int;
+   wire           tx_tlast_int;
+   wire           tx_tvalid_int;
+   wire           tx_tready_int;
+
+   always_comb begin
+      {tx_tuser,tx_tdata} = in_axis.tdata;
+      tx_tvalid           = in_axis.tvalid;
+      tx_tlast            = in_axis.tlast;
+      in_axis.tready      = tx_tready;
+   end
+
+   axis_fifo_512x69_2clk axis_fifo_512x69_2clk_i1
+     (
+      .s_aresetn(~tx_reset), // Active low, Async
+      // Input
+      .s_aclk(clk),
+      .s_axis_tvalid(tx_tvalid),
+      .s_axis_tready(tx_tready),
+      .s_axis_tdata(tx_tdata),
+      .s_axis_tuser(tx_tuser),
+      .s_axis_tlast(tx_tlast),
+      // Output
+      .m_aclk(mac_gmii.rxclk),
+      .m_axis_tvalid(tx_tvalid_int),
+      .m_axis_tready(tx_tready_int),
+      .m_axis_tdata(tx_tdata_int),
+      .m_axis_tuser(tx_tuser_int),
+      .m_axis_tlast(tx_tlast_int)
+      );
+
+   axi64_to_ll8 #(.START_BYTE(6)) axi64_to_ll8_i1
+     (
+      .clk(mac_gmii.txclk),
+      .reset(tx_reset),
+      .clear(1'b0),
+      .axi64_tdata(tx_tdata_int),
+      .axi64_tlast(tx_tlast_int),
+      .axi64_tuser(tx_tuser_int),
+      .axi64_tvalid(tx_tvalid_int),
+      .axi64_tready(tx_tready_int),
+      .ll_data(tx_ll_data),
+      .ll_eof(tx_ll_eof),
+      .ll_src_rdy(tx_ll_src_rdy),
+      .ll_dst_rdy(tx_ll_dst_rdy)
+      );
+
+   ll8_to_txmac ll8_to_txmac_i1
+     (
+      .clk(mac_gmii.txclk),
+      .reset(tx_reset),
+      .clear(1'b0),
+      .ll_data(tx_ll_data),
+      .ll_eof(tx_ll_eof),
+      .ll_src_rdy(tx_ll_src_rdy),
+      .ll_dst_rdy(tx_ll_dst_rdy),
+      .tx_data(tx_data),
+      .tx_valid(tx_valid),
+      .tx_error(tx_error),
+      .tx_ack(tx_ack)
+      );
+
+   //-------------------------------------------------------------------------------
+   // Pause Frame Processing
+   //-------------------------------------------------------------------------------
+   generate
+      if (RX_FLOW_CTRL==1)
+	flow_ctrl_rx flow_ctrl_rx_i0
+	  (
+           .pause_request_en(pause_request_en),
+           .pause_time(pause_time),
+           .pause_thresh(pause_thresh),
+	   .rx_clk(mac_gmii.rxclk),
+           .rx_reset(rx_reset),
+           .rx_fifo_space(rx_fifo_space),
+	   .txclk(mac_gmii.txclk),
+           .tx_reset(tx_reset),
+           .pause_req(pause_req),
+           .pause_time_req(pause_time_req)
+           );
+   endgenerate
+
+endmodule // gemac_wrapper
+`default_nettype wire

--- a/lib/ethernet/network.rdl
+++ b/lib/ethernet/network.rdl
@@ -1,0 +1,28 @@
+regfile network {
+  desc = "Networking Registers";
+  //-----------------------------------
+  // Xilinx PCS/PMA
+  //-----------------------------------
+
+  reg {
+    name="PCS PMA Control";
+    field {
+      sw=rw;
+      hw=r;
+      name="";
+      desc="";
+    } control [31:0] = 0x0;
+  } pcs_pma_control0 @ 0x0;
+
+  reg {
+    name="PCS PMA Status";
+    field {
+      sw=r;
+      hw=w;
+      name="";
+      desc="";
+    } status [31:0] = 0x0;
+  } pcs_pma_status0;
+  
+};
+

--- a/lib/ethernet/port_1000basex.sv
+++ b/lib/ethernet/port_1000basex.sv
@@ -1,0 +1,128 @@
+//-----------------------------------------------------------------------------
+// File:    port_1000basex.sv
+//
+// Author:  Ian Buckley, Ion Concepts LLC.
+//
+// Description:
+// Provdes 68 b AXIS interface to core passing ethernet frames.
+// Instantiates Xilinx PCS/PMA IP for transceiver
+// Uses legacy Ettus 1G MAC
+//
+//
+//
+// License: CERN-OHL-P (See LICENSE.md)
+//
+//-----------------------------------------------------------------------------
+`include "global_defs.svh"
+
+module port_1000basex
+  (
+   input wire	       clk,
+   input wire	       rst,
+   // For Ultrascale+ this can be between 6.25MHz and 62.5MHz (See PG047)
+   input wire	       independent_clock_bufg,
+   // CSR interface
+   input wire [31:0]   csr_gmii_ctl,
+   output logic [31:0] csr_gmii_stat,
+   //-------------------------------------------------------------------------------
+   // Transceiver clock
+   //-------------------------------------------------------------------------------
+   input wire	       refclk_p,
+   input wire	       refclk_n,
+   //-------------------------------------------------------------------------------
+   // External Ethernet Base-X
+   //-------------------------------------------------------------------------------
+   input wire	       rx_p,
+   input wire	       rx_n,
+   output wire	       tx_p,
+   output wire	       tx_n,
+   //-------------------------------------------------------------------------------
+   // Ethernet Management
+   //-------------------------------------------------------------------------------
+   //i2c.master i2c_sfp,
+   //-------------------------------------------------------------------------------
+   // Ethernet packet AXIS Busses
+   //-------------------------------------------------------------------------------
+   axis_t.master axis_ethernet_out,
+   axis_t.slave axis_ethernet_in
+   );
+
+   //-------------------------------------------------------------------------------
+   // 125MHz clock domain driven from PCS/PMA
+   //-------------------------------------------------------------------------------
+   wire clk_125;
+
+   // Ethernet specific buses
+   gmii_t gmii_eth0();
+   mdio_t phy_mdio();
+   
+   //-------------------------------------------------------------------------------
+   // MAC for external ethernet PCS/PMA
+   // Wrapper on Ettus 1G MAC provides clock domain handoff,
+   // interface conversion to DiRT, and FIFO buffering.
+   //-------------------------------------------------------------------------------
+   gemac_wrapper
+     #(
+       .RX_FLOW_CTRL(0),
+       .PORTNUM(8'd0)
+       )
+   gemac_wrapper_i0
+     (
+      .clk(clk),
+      .clk125(clk_125),
+      .rst(rst),
+      //-------------------------------------------------------------------------------
+      // GMII Interface
+      //-------------------------------------------------------------------------------
+      .gmii_reset(),
+      .mac_gmii(gmii_eth0),
+      //-------------------------------------------------------------------------------
+      // AXIS interfaces
+      //-------------------------------------------------------------------------------
+      .in_axis(axis_ethernet_in),
+      .out_axis(axis_ethernet_out)
+      );
+   
+
+   //-------------------------------------------------------------------------------
+   // 1G Ethernet PCS/PMA wrapper
+   //-------------------------------------------------------------------------------
+   eth_pcs_pma_1g_wrapper
+     #(
+       .XILINX_CLOCKING(1'b0) // Avoid multidriver issue on GMII txclk
+       )
+   eth_pcs_pma_1g_wrapper_i0
+     (
+      .clk          (clk),
+      .reset        (rst),
+      .clk_125      (clk_125),
+      .independent_clock_bufg(independent_clock_bufg),
+      //-------------------------------------------------------------------------------
+      // CSR registers
+      //-------------------------------------------------------------------------------
+      .gmii_ctl     (csr_gmii_ctl),
+      .gmii_stat    (csr_gmii_stat),
+      //-------------------------------------------------------------------------------
+      // MDIO Interface
+      //-------------------------------------------------------------------------------
+      .phy_mdio     (phy_mdio),
+      //-------------------------------------------------------------------------------
+      // GMII Interface
+      //-------------------------------------------------------------------------------
+      .phy_gmii     (gmii_eth0),
+      //-------------------------------------------------------------------------------
+      // Transceiver package pins
+      //-------------------------------------------------------------------------------
+      .gtrefclk_p   (refclk_p),
+      .gtrefclk_n   (refclk_n),
+      .rxp          (rx_p),
+      .rxn          (rx_n),
+      .txp          (tx_p),
+      .txn          (tx_n)
+      );
+
+endmodule // port_1000basex
+
+      
+      
+      


### PR DESCRIPTION
Try to create generic gemac port that will work across different device and transceiver families.
Still omits actual .xci but should probably include notes on how it should be configured to fit here.
There is a possibility of name collision here with some closed repos that use DiRT with`eth_pcs_pma_1g_wrapper.sv` which has been used repeatedly without a vendor name prefix to uniquify it.