### PR TITLE
ISSUE-48: Fix long delay in startup of TIME_REPORTS.

### DIFF
--- a/lib/axis/axis_time_report.sv
+++ b/lib/axis/axis_time_report.sv
@@ -57,17 +57,16 @@ module axis_time_report
 
 
    // Count down interval between TIME_REPORTs
-   // Counter is initialized to 1 so that we can use simple equality test
-   // to check for reset condition.
+   // Counter is initialized to 1 
    always_ff @(posedge clk)
      if(rst) begin
         counter <= 16'd1;
         generate_pkt <= 1'b0;
      end else if (~csr_enable) begin
-	counter <= 16'd1;
+        counter <= 16'd1;
         generate_pkt <= 1'b0;
      end else if (current_time[7:0] == 8'h00) begin
-        if (counter == csr_period) begin
+        if (counter >= csr_period) begin
            generate_pkt <= 1'b1;
            counter <= 16'b1;
         end else begin

--- a/lib/axis/axis_time_report.sv
+++ b/lib/axis/axis_time_report.sv
@@ -5,7 +5,7 @@
 //
 // Description:
 // This module emits TIME_REPORT packets on demand.
-// It maintains it's own Sequence Number counter. 
+// It maintains it's own Sequence Number counter.
 // FlowID is applied externally but should
 // not be changed during operation, only when dissabled.
 //
@@ -54,7 +54,7 @@ module axis_time_report
    logic [15:0]            counter;
    logic [7:0]             seq_num;
    logic                   generate_pkt;
-   
+
 
    // Count down interval between TIME_REPORTs
    // Counter is initialized to 1 so that we can use simple equality test
@@ -90,7 +90,7 @@ module axis_time_report
 
    always_ff @(posedge clk) begin
       if (rst) begin
-         state <= S_IDLE;48
+         state <= S_IDLE;
       end else begin
          case (state)
            // Spin in this state until the generation of a packet is triggered.
@@ -119,9 +119,9 @@ module axis_time_report
       axis_time_out.tlast = (state == S_TIME);
       case(state)
         S_HEADER  : axis_time_out.tdata = { C_PKT_TYPE, seq_num, C_TIME_PACKET_LENGTH, csr_flow_id };
-        S_TIME    : axis_time_out.tdata = current_time; 
+        S_TIME    : axis_time_out.tdata = current_time;
         default : axis_time_out.tdata = 64'd0; // Arbitrary default.
       endcase // case (state)
    end
 
-endmodule 
+endmodule

--- a/lib/axis/axis_time_report.sv
+++ b/lib/axis/axis_time_report.sv
@@ -63,6 +63,9 @@ module axis_time_report
      if(rst) begin
         counter <= 16'd1;
         generate_pkt <= 1'b0;
+     end else if (~csr_enable) begin
+	counter <= 16'd1;
+        generate_pkt <= 1'b0;
      end else if (current_time[7:0] == 8'h00) begin
         if (counter == csr_period) begin
            generate_pkt <= 1'b1;
@@ -87,7 +90,7 @@ module axis_time_report
 
    always_ff @(posedge clk) begin
       if (rst) begin
-         state <= S_IDLE;
+         state <= S_IDLE;48
       end else begin
          case (state)
            // Spin in this state until the generation of a packet is triggered.

--- a/lib/axis/axis_time_report_unit_test.sv
+++ b/lib/axis/axis_time_report_unit_test.sv
@@ -26,7 +26,7 @@ module axis_time_report_unit_test;
    string name = "axis_time_report_ut";
    svunit_testcase svunit_ut;
 
- 
+
    logic clk;
    logic rst;
 
@@ -34,14 +34,14 @@ module axis_time_report_unit_test;
    // CSRs
    //
    logic csr_enable;
-   logic [15:0]	csr_period;  
-   logic [31:0]	csr_flow_id;
+   logic [15:0] csr_period;
+   logic [31:0] csr_flow_id;
 
    // System time
-   logic [63:0]	current_time;
-   
-   
-   // Bus between UUT egress0 and 
+   logic [63:0] current_time;
+
+
+   // Bus between UUT egress0 and
    pkt_stream_t out_axis(.clk(clk));
 
    // Declarations for Stimulus Thread(s)
@@ -51,7 +51,7 @@ module axis_time_report_unit_test;
 
    // Declarations for Response Thread(s)
    DRaTPacket response_packet;
-   
+
    // Watchdog
    int          timeout;
 
@@ -71,9 +71,9 @@ module axis_time_report_unit_test;
 
    always_ff @(posedge clk) begin
       if (rst)
-	current_time <= 0;
+        current_time <= 0;
       else
-	current_time <= current_time + 1 ;
+        current_time <= current_time + 1 ;
    end
 
   //===================================
@@ -176,12 +176,12 @@ module axis_time_report_unit_test;
 
    fork
       begin : load_stimulus
-	 @(posedge clk);
-	 csr_enable <= 0;
-	 csr_period <= 10;
-	 csr_flow_id <= {DST0,SRC0};
-	 @(posedge clk);
-	 csr_enable <= 1;
+         @(posedge clk);
+         csr_enable <= 0;
+         csr_period <= 10;
+         csr_flow_id <= {DST0,SRC0};
+         @(posedge clk);
+         csr_enable <= 1;
          ready_to_test <= 1;
          //
          `INFO("gross_error_check): Stimulus Done");
@@ -191,45 +191,45 @@ module axis_time_report_unit_test;
 
       // Response thread for output
       begin: read_response_out
-	 // This simulation should produce TBD
+         // This simulation should produce TBD
          //
-	 while (!ready_to_test) @(posedge clk);
-	 
+         while (!ready_to_test) @(posedge clk);
+
          response_packet = new;
          response_packet.copy_to_pkt(out_axis);
          response_packet.assert_time_report_packet(
-						   0,           // SEQ NUM
-						   {DST0,SRC0}, // FLOWID
-						   0,           // TIMESTAMP
-						   'd2000,      // TIMESTAMP MIN
-						   'd3000,      // TIMESTAMP MAX
-						   1            // VERBOSE
-						   );
+                                                   0,           // SEQ NUM
+                                                   {DST0,SRC0}, // FLOWID
+                                                   0,           // TIMESTAMP
+                                                   'd2000,      // TIMESTAMP MIN
+                                                   'd3000,      // TIMESTAMP MAX
+                                                   1            // VERBOSE
+                                                   );
 
-	 response_packet.copy_to_pkt(out_axis);
-	 
+         response_packet.copy_to_pkt(out_axis);
+
          response_packet.assert_time_report_packet(
-						   1,           // SEQ NUM
-						   {DST0,SRC0}, // FLOWID
-						   0,           // TIMESTAMP
-						   'd5000,      // TIMESTAMP MIN
-						   'd6000,      // TIMESTAMP MAX
-						   1            // VERBOSE
-						   );
+                                                   1,           // SEQ NUM
+                                                   {DST0,SRC0}, // FLOWID
+                                                   0,           // TIMESTAMP
+                                                   'd5000,      // TIMESTAMP MIN
+                                                   'd6000,      // TIMESTAMP MAX
+                                                   1            // VERBOSE
+                                                   );
 
          `INFO("gross_error_check: Good Response");
-	 
-	 repeat(100) @(posedge clk);
-	 disable watchdog_thread;
+
+         repeat(100) @(posedge clk);
+         disable watchdog_thread;
       end // block: read_response_out
 
       begin : watchdog_thread
-	 timeout = 10000;
-	 while(1) begin
-	    `FAIL_IF(timeout==0);
-	    timeout = timeout - 1;
-	    @(negedge clk);
-	 end
+         timeout = 10000;
+         while(1) begin
+            `FAIL_IF(timeout==0);
+            timeout = timeout - 1;
+            @(negedge clk);
+         end
       end
    join
 
@@ -239,7 +239,7 @@ module axis_time_report_unit_test;
      `SVUNIT_TESTS_END
 
        task idle_all();
-	  out_axis.axis.idle_slave();
+          out_axis.axis.idle_slave();
        endtask // idle_all
 
 endmodule

--- a/lib/axis/axis_time_report_unit_test.sv
+++ b/lib/axis/axis_time_report_unit_test.sv
@@ -166,10 +166,9 @@ module axis_time_report_unit_test;
   //===================================
   // Test:
   //
-  // pass_data
+  // gross_error_check
+  // - Easy simulation just looks at two emited time_reports.
   //
-  // Feed packets to fifo
-  // Check all emerge in order and unaltered.
   //===================================
   `SVTEST(gross_error_check)
   `INFO("Simple test for gross errors");
@@ -184,7 +183,7 @@ module axis_time_report_unit_test;
          csr_enable <= 1;
          ready_to_test <= 1;
          //
-         `INFO("gross_error_check): Stimulus Done");
+         `INFO("gross_error_check: Stimulus Done");
          //
       end // block: load_stimulus
 
@@ -200,7 +199,7 @@ module axis_time_report_unit_test;
          response_packet.assert_time_report_packet(
                                                    0,           // SEQ NUM
                                                    {DST0,SRC0}, // FLOWID
-                                                   0,           // TIMESTAMP
+                                                   'd2563,      // TIMESTAMP
                                                    'd2000,      // TIMESTAMP MIN
                                                    'd3000,      // TIMESTAMP MAX
                                                    1            // VERBOSE
@@ -211,13 +210,109 @@ module axis_time_report_unit_test;
          response_packet.assert_time_report_packet(
                                                    1,           // SEQ NUM
                                                    {DST0,SRC0}, // FLOWID
-                                                   0,           // TIMESTAMP
+                                                   'd5123,      // TIMESTAMP
                                                    'd5000,      // TIMESTAMP MIN
                                                    'd6000,      // TIMESTAMP MAX
                                                    1            // VERBOSE
                                                    );
 
          `INFO("gross_error_check: Good Response");
+
+         repeat(100) @(posedge clk);
+         disable watchdog_thread;
+      end // block: read_response_out
+
+      begin : watchdog_thread
+         timeout = 10000;
+         while(1) begin
+            `FAIL_IF(timeout==0);
+            timeout = timeout - 1;
+            @(negedge clk);
+         end
+      end
+   join
+
+   `SVTEST_END
+
+  //===================================
+  // Test:
+  //
+  // change_period_on_the_fly
+  // - Chnage period to be shorter after two time_report packets
+  // - verify it changes without long pause
+  //===================================
+  `SVTEST(change_period_on_the_fly)
+   `INFO("Test that shortening period is immediately adopted.");
+
+   fork
+      begin : load_stimulus
+         @(posedge clk);
+         csr_enable <= 0;
+         csr_period <= 10;
+         csr_flow_id <= {DST1,SRC1};
+         @(posedge clk);
+         csr_enable <= 1;
+         ready_to_test <= 1;
+	 repeat(7000) @(posedge clk);
+	 csr_period <= 5;
+         //
+         `INFO("change_period_on_the_fly: Stimulus Done");
+         //
+      end // block: load_stimulus
+
+
+      // Response thread for output
+      begin: read_response_out
+         // This simulation should produce TBD
+         //
+         while (!ready_to_test) @(posedge clk);
+
+         response_packet = new;
+         response_packet.copy_to_pkt(out_axis);
+         response_packet.assert_time_report_packet(
+                                                   0,           // SEQ NUM
+                                                   {DST1,SRC1}, // FLOWID
+                                                   'd2563,      // TIMESTAMP
+                                                   'd2000,      // TIMESTAMP MIN
+                                                   'd3000,      // TIMESTAMP MAX
+                                                   1            // VERBOSE
+                                                   );
+
+         response_packet.copy_to_pkt(out_axis);
+
+         response_packet.assert_time_report_packet(
+                                                   1,           // SEQ NUM
+                                                   {DST1,SRC1}, // FLOWID
+                                                   'd5123,      // TIMESTAMP
+                                                   'd5000,      // TIMESTAMP MIN
+                                                   'd6000,      // TIMESTAMP MAX
+                                                   1            // VERBOSE
+                                                   );
+         // Should now trigger the instant that the period is changed
+         // as count has exceeded the new period
+         response_packet.copy_to_pkt(out_axis);
+
+         response_packet.assert_time_report_packet(
+                                                   2,           // SEQ NUM
+                                                   {DST1,SRC1}, // FLOWID
+                                                   'd7171,         // TIMESTAMP
+                                                   'd7000,      // TIMESTAMP MIN
+                                                   'd8000,      // TIMESTAMP MAX
+                                                   1            // VERBOSE
+                                                   );
+
+         response_packet.copy_to_pkt(out_axis);
+
+         response_packet.assert_time_report_packet(
+                                                   3,           // SEQ NUM
+                                                   {DST1,SRC1}, // FLOWID
+                                                   'd8451,         // TIMESTAMP
+                                                   'd8000,      // TIMESTAMP MIN
+                                                   'd9000,      // TIMESTAMP MAX
+                                                   1            // VERBOSE
+                                                   );
+
+         `INFO("change_period_on_the_fly: Good Response");
 
          repeat(100) @(posedge clk);
          disable watchdog_thread;

--- a/lib/axis/axis_time_report_unit_test.sv
+++ b/lib/axis/axis_time_report_unit_test.sv
@@ -1,0 +1,245 @@
+//-------------------------------------------------------------------------------
+// File:    axis_time_report_unit_test.sv
+//
+// Author:  Ian Buckley, Ion Concepts LLC
+//
+// Description:
+// Verify thtat:
+// * Discards ingressing packets due to lack of capacity
+//
+//
+// License: CERN-OHL-P (See LICENSE.md)
+//
+//-------------------------------------------------------------------------------
+
+`include "global_defs.svh"
+`include "svunit_defines.svh"
+`include "axis_time_report.sv"
+`include "drat_protocol.sv"
+
+module axis_time_report_unit_test;
+   timeunit 1ns;
+   timeprecision 1ps;
+   import drat_protocol::*;
+   import svunit_pkg::svunit_testcase;
+
+   string name = "axis_time_report_ut";
+   svunit_testcase svunit_ut;
+
+ 
+   logic clk;
+   logic rst;
+
+   //
+   // CSRs
+   //
+   logic csr_enable;
+   logic [15:0]	csr_period;  
+   logic [31:0]	csr_flow_id;
+
+   // System time
+   logic [63:0]	current_time;
+   
+   
+   // Bus between UUT egress0 and 
+   pkt_stream_t out_axis(.clk(clk));
+
+   // Declarations for Stimulus Thread(s)
+   logic        enable_stimulus;
+   logic        enable_response;
+   logic        ready_to_test;
+
+   // Declarations for Response Thread(s)
+   DRaTPacket response_packet;
+   
+   // Watchdog
+   int          timeout;
+
+   //
+   // Generate clk
+   //
+   initial begin
+      clk <= 1'b0;
+   end
+
+   always
+     #5 clk <= ~clk;
+
+   //
+   // Provide time that increments on sample clock domain.
+   //
+
+   always_ff @(posedge clk) begin
+      if (rst)
+	current_time <= 0;
+      else
+	current_time <= current_time + 1 ;
+   end
+
+  //===================================
+  // This is the UUT that we're
+  // running the Unit Tests on
+  //===================================
+
+
+   axis_time_report uut
+     (
+      .clk(clk),
+      .rst(rst),
+      //
+      // CSR interface
+      //
+      .csr_enable(csr_enable),
+      .csr_period(csr_period),
+      .csr_flow_id(csr_flow_id),
+      // Current System Time
+      .current_time(current_time),
+      // Dirt/DRat packetized stream out
+      .axis_time_out(out_axis.axis)
+
+      );
+
+   //-------------------------------------------------------------------------------
+   // Dump outout
+   //-------------------------------------------------------------------------------
+   axis_null_sink null_sink_router2eth_i0
+     (
+      .in_axis(out_axis.axis)
+      );
+
+
+   //===================================
+   // Build
+   //===================================
+   function void build();
+      svunit_ut = new(name);
+   endfunction
+
+
+   //===================================
+   // Setup for running the Unit Tests
+   //===================================
+   task setup();
+      svunit_ut.setup();
+      /* Place Setup Code Here */
+      // Reset UUT
+      @(posedge clk);
+      rst <= 1'b1;
+      ready_to_test <= 0;
+      csr_enable <= 0;
+      csr_period <= 0;
+      csr_flow_id <= 0;
+      // Take all bench AXIS buses to a quiescent state
+      idle_all();
+      // De-assert reset after 10 clock cycles.
+      repeat(10) @(posedge clk);
+      rst <= 1'b0;
+   endtask
+
+
+   //===================================
+   // Here we deconstruct anything we
+   // need after running the Unit Tests
+   //===================================
+   task teardown();
+      svunit_ut.teardown();
+      /* Place Teardown Code Here */
+   endtask
+
+
+  //===================================
+  // All tests are defined between the
+  // SVUNIT_TESTS_BEGIN/END macros
+  //
+  // Each individual test must be
+  // defined between `SVTEST(_NAME_)
+  // `SVTEST_END
+  //
+  // i.e.
+  //   `SVTEST(mytest)
+  //     <test code>
+  //   `SVTEST_END
+  //===================================
+  `SVUNIT_TESTS_BEGIN
+
+
+  //===================================
+  // Test:
+  //
+  // pass_data
+  //
+  // Feed packets to fifo
+  // Check all emerge in order and unaltered.
+  //===================================
+  `SVTEST(gross_error_check)
+  `INFO("Simple test for gross errors");
+
+   fork
+      begin : load_stimulus
+	 @(posedge clk);
+	 csr_enable <= 0;
+	 csr_period <= 10;
+	 csr_flow_id <= {DST0,SRC0};
+	 @(posedge clk);
+	 csr_enable <= 1;
+         ready_to_test <= 1;
+         //
+         `INFO("gross_error_check): Stimulus Done");
+         //
+      end // block: load_stimulus
+
+
+      // Response thread for output
+      begin: read_response_out
+	 // This simulation should produce TBD
+         //
+	 while (!ready_to_test) @(posedge clk);
+	 
+         response_packet = new;
+         response_packet.copy_to_pkt(out_axis);
+         response_packet.assert_time_report_packet(
+						   0,           // SEQ NUM
+						   {DST0,SRC0}, // FLOWID
+						   0,           // TIMESTAMP
+						   'd2000,      // TIMESTAMP MIN
+						   'd3000,      // TIMESTAMP MAX
+						   1            // VERBOSE
+						   );
+
+	 response_packet.copy_to_pkt(out_axis);
+	 
+         response_packet.assert_time_report_packet(
+						   1,           // SEQ NUM
+						   {DST0,SRC0}, // FLOWID
+						   0,           // TIMESTAMP
+						   'd5000,      // TIMESTAMP MIN
+						   'd6000,      // TIMESTAMP MAX
+						   1            // VERBOSE
+						   );
+
+         `INFO("gross_error_check: Good Response");
+	 
+	 repeat(100) @(posedge clk);
+	 disable watchdog_thread;
+      end // block: read_response_out
+
+      begin : watchdog_thread
+	 timeout = 10000;
+	 while(1) begin
+	    `FAIL_IF(timeout==0);
+	    timeout = timeout - 1;
+	    @(negedge clk);
+	 end
+      end
+   join
+
+   `SVTEST_END
+
+
+     `SVUNIT_TESTS_END
+
+       task idle_all();
+	  out_axis.axis.idle_slave();
+       endtask // idle_all
+
+endmodule

--- a/lib/global/drat_protocol.sv
+++ b/lib/global/drat_protocol.sv
@@ -200,12 +200,12 @@ typedef struct packed
 typedef struct packed
                {
                   logic [7:0] padding;
-		  logic	      read_not_write;
-		  logic [14:0] address;
-		  logic [7:0]  data;
-		  spi_status_t spi_status;
+                  logic       read_not_write;
+                  logic [14:0] address;
+                  logic [7:0]  data;
+                  spi_status_t spi_status;
                   logic [7:0]  expected_seq_id;
-		  logic [7:0]  received_seq_id;
+                  logic [7:0]  received_seq_id;
                } spi_command_beat_t;
 
 
@@ -214,9 +214,9 @@ typedef union packed
               {
                  logic [63:0] beat;
                  int16_complex_t int16_complex;
-		 int16_real_t int16_real;
+                 int16_real_t int16_real;
                  status_beat_t status_beat;
-		 spi_command_beat_t spi_command_beat;
+                 spi_command_beat_t spi_command_beat;
               } payload_beat_t;
 
 
@@ -323,8 +323,8 @@ function logic payload_compare(input pkt_payload_t a, input pkt_payload_t b);
            $display("Payload Beat missmatch: %x vs %x at beat %d",a[i],b[i],i);
            return (0);
         end //else begin
-	  //$display("Payload Beat     match: %x vs %x at beat %d",a[i],b[i],i);
-	  // end
+          //$display("Payload Beat     match: %x vs %x at beat %d",a[i],b[i],i);
+          // end
     end
     return(1);
 endfunction
@@ -601,11 +601,12 @@ class DRaTPacket;
                                       bit [63:0] timestamp_max=0,
                                       status_type_t status_type,
                                       bit [7:0] status_seq_id,
-			              bit verbose = 0
+                                      bit verbose = 0
                                       );
-				      string s1, s2;
-				      s1.itoa(this.get_timestamp());
-				      s2.itoa(timestamp_min);
+      string s1, s2, s3;
+      s1.itoa(this.get_timestamp());
+      s2.itoa(timestamp_min);
+      s3.itoa(timestamp_max);
       if (verbose) print_header(header);
       `FAIL_UNLESS_EQUAL(this.get_packet_type() , STATUS);
       `FAIL_UNLESS_EQUAL(this.get_seq_id() , seq_id)
@@ -613,24 +614,23 @@ class DRaTPacket;
       `FAIL_UNLESS_EQUAL(this.get_flow_id() , flow_id);
        if (timestamp != 0) `FAIL_UNLESS_EQUAL(this.get_timestamp(), timestamp);
        if (timestamp_min != 0) `FAIL_UNLESS_LOG(this.get_timestamp() > timestamp_min, {s1 , " > ", s2}  );
-       if (timestamp_max != 0) `FAIL_UNLESS(this.get_timestamp() < timestamp_max);
+       if (timestamp_max != 0) `FAIL_UNLESS_LOG(this.get_timestamp() < timestamp_max, {s1 , " < ", s3} );
        `FAIL_UNLESS_EQUAL(this.get_status_type() , status_type);
        `FAIL_UNLESS_EQUAL(this.get_status_seq_id(), status_seq_id);
-      if (verbose) print_header(header);
     endtask: assert_status_packet
 
     // Verification function for SPI_RESPONSE format packets
     task assert_spi_response_packet(
                                     bit [7:0]  seq_id,
                                     bit [15:0] length,
-				    flow_id_t flow_id,
+                                    flow_id_t flow_id,
                                     bit [63:0] timestamp=0,
                                     bit [63:0] timestamp_min=0,
                                     bit [63:0] timestamp_max=0,
-				    spi_status_t spi_status,
+                                    spi_status_t spi_status,
                                     bit [7:0]  expected_seq_id,
-				    bit [7:0]  received_seq_id,
-				    bit verbose = 0
+                                    bit [7:0]  received_seq_id,
+                                    bit verbose = 0
                                     );
        if (verbose) print_header(header);
        `FAIL_UNLESS_EQUAL(this.get_packet_type() , SPI_RESPONSE);
@@ -648,11 +648,11 @@ class DRaTPacket;
    // Verification function for TIME_REPORT format packets
    task assert_time_report_packet(
                                   bit [7:0]  seq_id,
-				  flow_id_t flow_id,
+                                  flow_id_t flow_id,
                                   bit [63:0] timestamp=0,
                                   bit [63:0] timestamp_min=0,
                                   bit [63:0] timestamp_max=0,
-				  bit verbose=0
+                                  bit verbose=0
                                    );
       if (verbose) print_header(header);
       `FAIL_UNLESS_EQUAL(this.get_packet_type() , TIME_REPORT);
@@ -664,7 +664,7 @@ class DRaTPacket;
       if (timestamp_max != 0) `FAIL_UNLESS(this.get_timestamp() < timestamp_max);
    endtask: assert_time_report_packet
 
-   
+
    // Interfaces passed as args to tasks and functions must be virtual:
    // ieee 1800-2017: 25.9 "Virtual Interfaces"
    task copy_to_pkt(virtual interface pkt_stream_t axis_bus);
@@ -672,7 +672,7 @@ class DRaTPacket;
       logic [63:0] tdata;
       logic        tlast;
 
-      axis_bus.pull_beat(tdata,tlast); 
+      axis_bus.pull_beat(tdata,tlast);
       `FAIL_UNLESS_EQUAL(tlast,0);
       this.set_raw_header(tdata);
       axis_bus.pull_beat(tdata,tlast);
@@ -695,8 +695,8 @@ class DRaTPacket;
            assert(payload_compare(this.payload,test_packet.get_payload()));
            return(1); // Should not get here if assert triggered
         end else begin
-	   //if (!header_compare(this.header,test_packet.get_header())) $display("Header compare failed.");
-	   //if (!payload_compare(this.payload,test_packet.get_payload())) $display("Payload compare failed.");
+           //if (!header_compare(this.header,test_packet.get_header())) $display("Header compare failed.");
+           //if (!payload_compare(this.payload,test_packet.get_payload())) $display("Payload compare failed.");
            return(header_compare(this.header,test_packet.get_header()) &&
                   payload_compare(this.payload,test_packet.get_payload()));
         end

--- a/lib/global/drat_protocol.sv
+++ b/lib/global/drat_protocol.sv
@@ -600,17 +600,23 @@ class DRaTPacket;
                                       bit [63:0] timestamp_min=0,
                                       bit [63:0] timestamp_max=0,
                                       status_type_t status_type,
-                                      bit [7:0] status_seq_id
+                                      bit [7:0] status_seq_id,
+			              bit verbose = 0
                                       );
-       `FAIL_UNLESS_EQUAL(this.get_packet_type() , STATUS);
-       `FAIL_UNLESS_EQUAL(this.get_seq_id() , seq_id)
-       `FAIL_UNLESS_EQUAL(this.get_length() , length);
-       `FAIL_UNLESS_EQUAL(this.get_flow_id() , flow_id);
+				      string s1, s2;
+				      s1.itoa(this.get_timestamp());
+				      s2.itoa(timestamp_min);
+      if (verbose) print_header(header);
+      `FAIL_UNLESS_EQUAL(this.get_packet_type() , STATUS);
+      `FAIL_UNLESS_EQUAL(this.get_seq_id() , seq_id)
+      `FAIL_UNLESS_EQUAL(this.get_length() , length);
+      `FAIL_UNLESS_EQUAL(this.get_flow_id() , flow_id);
        if (timestamp != 0) `FAIL_UNLESS_EQUAL(this.get_timestamp(), timestamp);
-       if (timestamp_min != 0) `FAIL_UNLESS(this.get_timestamp() > timestamp_min);
+       if (timestamp_min != 0) `FAIL_UNLESS_LOG(this.get_timestamp() > timestamp_min, {s1 , " > ", s2}  );
        if (timestamp_max != 0) `FAIL_UNLESS(this.get_timestamp() < timestamp_max);
        `FAIL_UNLESS_EQUAL(this.get_status_type() , status_type);
        `FAIL_UNLESS_EQUAL(this.get_status_seq_id(), status_seq_id);
+      if (verbose) print_header(header);
     endtask: assert_status_packet
 
     // Verification function for SPI_RESPONSE format packets
@@ -623,8 +629,10 @@ class DRaTPacket;
                                     bit [63:0] timestamp_max=0,
 				    spi_status_t spi_status,
                                     bit [7:0]  expected_seq_id,
-				    bit [7:0]  received_seq_id
+				    bit [7:0]  received_seq_id,
+				    bit verbose = 0
                                     );
+       if (verbose) print_header(header);
        `FAIL_UNLESS_EQUAL(this.get_packet_type() , SPI_RESPONSE);
        `FAIL_UNLESS_EQUAL(this.get_seq_id() , seq_id)
        `FAIL_UNLESS_EQUAL(this.get_length() , length);
@@ -637,6 +645,26 @@ class DRaTPacket;
        `FAIL_UNLESS_EQUAL(this.get_spi_received_seq_id(), received_seq_id);
       endtask: assert_spi_response_packet
 
+   // Verification function for TIME_REPORT format packets
+   task assert_time_report_packet(
+                                  bit [7:0]  seq_id,
+				  flow_id_t flow_id,
+                                  bit [63:0] timestamp=0,
+                                  bit [63:0] timestamp_min=0,
+                                  bit [63:0] timestamp_max=0,
+				  bit verbose=0
+                                   );
+      if (verbose) print_header(header);
+      `FAIL_UNLESS_EQUAL(this.get_packet_type() , TIME_REPORT);
+      `FAIL_UNLESS_EQUAL(this.get_seq_id() , seq_id)
+      `FAIL_UNLESS_EQUAL(this.get_length() , 16);
+      `FAIL_UNLESS_EQUAL(this.get_flow_id() , flow_id);
+      if (timestamp != 0) `FAIL_UNLESS_EQUAL(this.get_timestamp(), timestamp);
+      if (timestamp_min != 0) `FAIL_UNLESS(this.get_timestamp() > timestamp_min);
+      if (timestamp_max != 0) `FAIL_UNLESS(this.get_timestamp() < timestamp_max);
+   endtask: assert_time_report_packet
+
+   
    // Interfaces passed as args to tasks and functions must be virtual:
    // ieee 1800-2017: 25.9 "Virtual Interfaces"
    task copy_to_pkt(virtual interface pkt_stream_t axis_bus);
@@ -648,7 +676,7 @@ class DRaTPacket;
       `FAIL_UNLESS_EQUAL(tlast,0);
       this.set_raw_header(tdata);
       axis_bus.pull_beat(tdata,tlast);
-      `FAIL_UNLESS_EQUAL(tlast,0);
+      // `FAIL_UNLESS_EQUAL(tlast,0); // Commented this line to support TIME_REPORT
       this.set_timestamp(tdata);
       payload = new[bytes_to_beats(this.header.length-16)];
       // Assert on tlast is done one pass in arrears so that we can check for tlast==1

--- a/lib/run_questa_gui_unit.sh
+++ b/lib/run_questa_gui_unit.sh
@@ -50,7 +50,7 @@ echo "runSVUnit"
 #    -permit_unmatched_virtual_intf solves a problem with virtual interfaces not matching any real interface
 #
 runSVUnit -s questa --c_arg "-incdir ../../global -incdir ../../axis -incdir ../../ethernet -incdir ../../spi \
-	  +libext+.sv +libext+.v -y ../../axis -y ../../dsp -y ../../ethernet -y ../../spi -y $XILINX_VIVADO/data/verilog/src/unisims" \
+	  +libext+.sv +libext+.v -y ../../axis -y ../../dsp -y ../../ethernet -y ../../global -y ../../spi -y $XILINX_VIVADO/data/verilog/src/unisims" \
          --r_arg "-gui -permit_unmatched_virtual_intf -voptargs=+acc=npr" -f dependencies.f -o sim $UNIT
 if [ $? -ne 0 ]; then exit 1 ; fi
 popd # 2>&1 > /dev/null

--- a/lib/run_questa_unit.sh
+++ b/lib/run_questa_unit.sh
@@ -50,7 +50,7 @@ echo "runSVUnit"
 #    -permit_unmatched_virtual_intf solves a problem with virtual interfaces not matching any real interface
 #
 runSVUnit -s questa --c_arg "-incdir ../../global -incdir ../../axis -incdir ../../ethernet -incdir ../../spi \
-	   +libext+.sv +libext+.v -y ../../axis -y ../../dsp -y ../../ethernet -y ../../spi -y $XILINX_VIVADO/data/verilog/src/unisims" \
+	   +libext+.sv +libext+.v -y ../../axis -y ../../dsp -y ../../ethernet -y ../../global -y ../../spi -y $XILINX_VIVADO/data/verilog/src/unisims" \
            --r_arg "-permit_unmatched_virtual_intf" -f dependencies.f -o sim $UNIT
 if [ $? -ne 0 ]; then exit 1 ; fi
 popd # 2>&1 > /dev/null


### PR DESCRIPTION
#48 
Hold timer counter in reset when time_reports not enabled. The period should be valid before or at enable time to ensure time_reports start immediately.

In fixing Issue #48 like this I made a design choice that the first time_report will be emitted after 1 period (with 8LSB's of current_time jitter). I could alternately have opted to initialize the counter to the period when not enable, which should cause a TIME_REPORT to be immediately emitted upon enable.


This module needs a dedicated unit test still. Testing on this PR will be performed at a system level.