### PR TITLE
Issue -50/51: Fix consumption packets

### DIFF
--- a/lib/axis/axis_pkt_to_stream_unit_test.sv
+++ b/lib/axis/axis_pkt_to_stream_unit_test.sv
@@ -730,14 +730,12 @@ module axis_pkt_to_stream_unit_test;
             // We are discarding Golden packets here that were lost as a result of the underflow.
             if ((response_pkt_count > 0) && (response_pkt_count < 5)) begin
                // Check for asserted tlast and increment calculated Seq Num if so.
-               // (Note: non-blocking increment needed for following code block)
                if (golden_tlast) begin
                   response_pkt_count = response_pkt_count + 1;
                end
                continue;
             end
             // Check for asserted tlast and increment calculated Seq Num if so.
-            // (Note: non-blocking increment needed for following code block)
             if (golden_tlast) begin
                response_pkt_count = response_pkt_count + 1;
             end
@@ -929,7 +927,7 @@ module axis_pkt_to_stream_unit_test;
          // for the 3rd packet must be purged,
          // as there is no equivalent response data to compare against.
          //
-         response_pkt_count <= 0;
+         response_pkt_count = 0;
          // Wait until stimulus is loaded.
          while (!ready_to_test) @(posedge clk);
          // 100% duty cycle on output bus
@@ -940,14 +938,17 @@ module axis_pkt_to_stream_unit_test;
             axis_golden_post.read_beat(golden_beat,golden_tlast);
             // Grab golden time stamp.
             golden_timestamp = golden_beat[95:32];
-            // Check for asserted tlast and increment calculated Seq Num if so.
-            // (Note: non-blocking increment needed for following code block)
-            if (golden_tlast) begin
-               response_pkt_count <= response_pkt_count + 1;
-            end
             // Break if we are reading packets with seq num 2
             if ((response_pkt_count > 1) && (response_pkt_count < 3)) begin
+	       // Check for asserted tlast and increment calculated Seq Num if so.
+               if (golden_tlast) begin
+		  response_pkt_count = response_pkt_count + 1;
+               end
                continue;
+            end
+	    // Check for asserted tlast and increment calculated Seq Num if so.
+            if (golden_tlast) begin
+	       response_pkt_count = response_pkt_count + 1;
             end
             // Pop response.
             axis_response_post.read_beat(response_beat,response_tlast);

--- a/lib/axis/axis_pkt_to_stream_unit_test.sv
+++ b/lib/axis/axis_pkt_to_stream_unit_test.sv
@@ -25,6 +25,7 @@
 //-----------------------------------------------------------------------------
 
 `include "svunit_defines.svh"
+`include "drat_protocol.sv"
 `include "axis_pkt_to_stream.sv"
 
 module axis_pkt_to_stream_unit_test;
@@ -43,13 +44,14 @@ module axis_pkt_to_stream_unit_test;
    logic  rst;
    // Watchdog
    int timeout;
-   
+
    // Time
    logic [63:0] current_time;
 
    // DUT Signals (non AXIS)
    logic [31:0] status_flow_id;
    logic [31:0] consumption_flow_id;
+   logic [7:0] consumption_period;
    logic        error_policy_next_packet;
    //logic        run;
    logic        deframer_enable;
@@ -102,8 +104,8 @@ module axis_pkt_to_stream_unit_test;
    // Post Buffer Consumption Bus
    pkt_stream_t axis_consumption_post(.clk(clk));
    // DUT Output bus
-   axis_t #(.WIDTH(32)) axis_response_gated(.clk(clk));
-   // Bus between response vavale and buffer with Time concatenated.
+   axis_t #(.WIDTH(32)) axis_response_concat(.clk(clk));
+   // Bus between response valve and buffer with Time concatenated.
    axis_t #(.WIDTH(96)) axis_response_pre(.clk(clk));
    // Post Buffer Output bus with Time concatenated.
    axis_t #(.WIDTH(96)) axis_response_post(.clk(clk));
@@ -153,6 +155,8 @@ module axis_pkt_to_stream_unit_test;
       .tx_control_enable(tx_control_enable),
       // System time in
       .current_time(current_time),
+      // Interval between consumption packets
+      .consumption_period(consumption_period),
       // FlowID to me used in status packet header
       .status_flow_id(status_flow_id),
       // FlowID to me used in consumption packet header
@@ -168,7 +172,7 @@ module axis_pkt_to_stream_unit_test;
       // Consumption pkt stream out
       .axis_consumption(axis_consumption_pre.axis),
       // Stream oriented raw IQ samples out
-      .axis_stream(axis_response_gated)
+      .axis_stream(axis_response_concat)
       );
 
     //-------------------------------------------------------------------------------
@@ -186,7 +190,9 @@ module axis_pkt_to_stream_unit_test;
                           .clk(clk),
                           .rst(rst),
                           .in_axis(axis_stimulus_pre.axis),
-                          .out_axis(axis_stimulus_post.axis)
+                          .out_axis(axis_stimulus_post.axis),
+			  .space(),
+			  .occupied()
                           );
 
     axis_demux4_wrapper #(
@@ -240,7 +246,9 @@ module axis_pkt_to_stream_unit_test;
                         .clk(clk),
                         .rst(rst),
                         .in_axis(axis_status_pre.axis),
-                        .out_axis(axis_status_post.axis)
+                        .out_axis(axis_status_post.axis),
+			.space(),
+			.occupied()
                         );
 
     //-------------------------------------------------------------------------------
@@ -254,7 +262,9 @@ module axis_pkt_to_stream_unit_test;
                              .clk(clk),
                              .rst(rst),
                              .in_axis(axis_consumption_pre.axis),
-                             .out_axis(axis_consumption_post.axis)
+                             .out_axis(axis_consumption_post.axis),
+			     .space(),
+			     .occupied()
                              );
 
     //-------------------------------------------------------------------------------
@@ -264,7 +274,7 @@ module axis_pkt_to_stream_unit_test;
     axis_valve_response_i (
                            .clk(clk),
                            .rst(rst),
-                           .in_axis(axis_response_gated),
+                           .in_axis(axis_response_concat),
                            .concat_data_in(current_time),
                            .out_axis(axis_response_pre),
                            .enable(enable_response)
@@ -277,7 +287,9 @@ module axis_pkt_to_stream_unit_test;
                           .clk(clk),
                           .rst(rst),
                           .in_axis(axis_response_pre),
-                          .out_axis(axis_response_post)
+                          .out_axis(axis_response_post),
+			  .space(),
+			  .occupied()
                           );
 
     //-------------------------------------------------------------------------------
@@ -291,7 +303,9 @@ module axis_pkt_to_stream_unit_test;
                          .clk(clk),
                          .rst(rst),
                          .in_axis(axis_golden_pre),
-                         .out_axis(axis_golden_post)
+                         .out_axis(axis_golden_post),
+			 .space(),
+			 .occupied()
                          );
 
 
@@ -317,6 +331,7 @@ module axis_pkt_to_stream_unit_test;
       rst <= 1'b1;
       status_flow_id <= {DST0,SRC0};
       consumption_flow_id <= {DST0,SRC0};
+      consumption_period <= 8'd1;
       ready_to_test <= 0;
       clks_per_sample <= 0;
       discard_enable <= 0;
@@ -582,7 +597,7 @@ module axis_pkt_to_stream_unit_test;
          enable_stimulus <= 1'b1;
          //
          `INFO("underflow_one_burst_one_clk_per_samp: Stimulus done");
-      end // block: load_stimulus
+      end // block: load_stimulus2
       //
       begin: read_status2
          // This simulation should produce the following status packets in this order:
@@ -603,8 +618,10 @@ module axis_pkt_to_stream_unit_test;
                                             'd1000,         // TIMESTAMP MIN
                                             'd1200,         // TIMESTAMP MAX
                                             UNDERFLOW,      // STATUS TYPE
-                                            0               // STATUS SEQ NUM
+                                            0,              // STATUS SEQ NUM
+                                            0               // VERBOSE
                                             );
+//       $display("STATUS: Received SeqID:0 UNDERFLOW");
 
          status_packet = new;
          status_packet.copy_to_pkt(axis_status_post);
@@ -616,8 +633,10 @@ module axis_pkt_to_stream_unit_test;
                                             'd1000,         // TIMESTAMP MIN
                                             'd1200,         // TIMESTAMP MAX
                                             LATE,           // STATUS TYPE
-                                            2               // STATUS SEQ NUM
+                                            2,              // STATUS SEQ NUM
+                                            0               // VERBOSE
                                             );
+//       $display("STATUS: Received SeqID:1 LATE");
 
          status_packet = new;
          status_packet.copy_to_pkt(axis_status_post);
@@ -629,8 +648,10 @@ module axis_pkt_to_stream_unit_test;
                                             'd1000,         // TIMESTAMP MIN
                                             'd1200,         // TIMESTAMP MAX
                                             LATE,           // STATUS TYPE
-                                            3               // STATUS SEQ NUM
+                                            3,              // STATUS SEQ NUM
+                                            0               // VERBOSE
                                             );
+//       $display("STATUS: Received SeqID:2 LATE");
 
          status_packet = new;
          status_packet.copy_to_pkt(axis_status_post);
@@ -642,10 +663,12 @@ module axis_pkt_to_stream_unit_test;
                                             'd1000,         // TIMESTAMP MIN
                                             'd1200,         // TIMESTAMP MAX
                                             LATE,           // STATUS TYPE
-                                            4               // STATUS SEQ NUM
+                                            4,              // STATUS SEQ NUM
+                                            0               // VERBOSE
                                             );
 
 
+//       $display("STATUS: Received SeqID:3 LATE");
 
          status_packet = new;
          status_packet.copy_to_pkt(axis_status_post);
@@ -657,8 +680,10 @@ module axis_pkt_to_stream_unit_test;
                                             'd1000,         // TIMESTAMP MIN
                                             'd1300,         // TIMESTAMP MAX
                                             EOB_ACK,        // STATUS TYPE
-                                            7               // STATUS SEQ NUM
+                                            7,              // STATUS SEQ NUM
+                                            0               // VERBOSE
                                             );
+//       $display("STATUS: Received SeqID:4 EOB_ACK");
 
          `INFO("underflow_one_burst_one_clk_per_samp: Good Status");
       end // block: read_status2
@@ -678,8 +703,10 @@ module axis_pkt_to_stream_unit_test;
                                                     'd1000,         // TIMESTAMP MIN
                                                     'd1400,         // TIMESTAMP MAX
                                                     ACK,            // STATUS TYPE
-                                                    i               // STATUS SEQ NUM
+                                                    i,              // STATUS SEQ NUM
+                                                    0               // VERBOSE
                                                     );
+//          $display("CONSUMPTION: Received SeqID:%d ACK",i);
          end
 
          `INFO("underflow_one_burst_one_clk_per_samp: Good Consumption");
@@ -694,7 +721,7 @@ module axis_pkt_to_stream_unit_test;
          // for the 2nd,3rd,& 4th packets must be purged,
          // as there is no equivalent response data to compare against.
          //
-         response_pkt_count <= 0;
+         response_pkt_count = 0;
          // Wait until stimulus is loaded.
          while (!ready_to_test) @(posedge clk);
          // 100% duty cycle on output bus
@@ -705,15 +732,20 @@ module axis_pkt_to_stream_unit_test;
             axis_golden_post.read_beat(golden_beat,golden_tlast);
             // Grab golden time stamp.
             golden_timestamp = golden_beat[95:32];
-            // Check for asserted tlast and increment calculated Seq Num if so.
-            // (Note: non-blocking increment needed for following code block)
-            if (axis_golden_post.tlast === 1) begin
-               response_pkt_count <= response_pkt_count + 1;
-            end
             // Continue without checking response if we are reading packets with seq nums 1|2|3|4
             // We are discarding Golden packets here that were lost as a result of the underflow.
             if ((response_pkt_count > 0) && (response_pkt_count < 5)) begin
+               // Check for asserted tlast and increment calculated Seq Num if so.
+               // (Note: non-blocking increment needed for following code block)
+               if (golden_tlast) begin
+                  response_pkt_count = response_pkt_count + 1;
+               end
                continue;
+            end
+            // Check for asserted tlast and increment calculated Seq Num if so.
+            // (Note: non-blocking increment needed for following code block)
+            if (golden_tlast) begin
+               response_pkt_count = response_pkt_count + 1;
             end
             // Pop response.
             axis_response_post.read_beat(response_beat,response_tlast);
@@ -721,12 +753,9 @@ module axis_pkt_to_stream_unit_test;
             response_timestamp = response_beat[95:32];
             // Compare golden time stamp to response timestamp.
             // Drain zero valued fill samples until timestamps match.
- 
+
             while (golden_timestamp > response_timestamp) begin
-               $display("Golden time: %d  Response Time: %d @ time: %d",golden_timestamp , response_timestamp, $time);
-               $display("Response Beat: %x",  response_beat[31:0]);
-               
-               // assert if response TDATA is not 0
+                // assert if response TDATA is not 0
                // IJB Removed this assert because the initial beats of the underflowing packet can get into the response
                //`FAIL_UNLESS_EQUAL(response_beat[31:0],32'd0);
                // Pop response.
@@ -734,8 +763,6 @@ module axis_pkt_to_stream_unit_test;
                // Grab reponse time stamp.
                response_timestamp = response_beat[95:32];
             end // while (golden_timestamp > response_timestamp)
-            $display("timestamps match: %d",golden_timestamp);
-            
             // if golden < response then always assert.
             if (golden_timestamp < response_timestamp) assert(0);
             // If golden == response then assert if golden TDATA != response TDATA
@@ -747,7 +774,7 @@ module axis_pkt_to_stream_unit_test;
          disable watchdog_thread;
       end // block: read_response
       //
-      
+
       begin : watchdog_thread
          timeout = 100000;
          while(1) begin
@@ -921,7 +948,7 @@ module axis_pkt_to_stream_unit_test;
             golden_timestamp = golden_beat[95:32];
             // Check for asserted tlast and increment calculated Seq Num if so.
             // (Note: non-blocking increment needed for following code block)
-            if (axis_golden_post.tlast === 1) begin
+            if (golden_tlast) begin
                response_pkt_count <= response_pkt_count + 1;
             end
             // Break if we are reading packets with seq num 2
@@ -949,10 +976,10 @@ module axis_pkt_to_stream_unit_test;
             count_resp += 1;
          end // while (axis_golden_post.tvalid)
          `INFO($sformatf("lost_pkt_one_burst_one_clk_per_samp: Good Response, checked %d beats", count_resp));
-
+         disable watchdog_thread;
       end // block: read_response
       //
-      
+
       begin : watchdog_thread
          timeout = 100000;
          while(1) begin
@@ -1124,7 +1151,7 @@ module axis_pkt_to_stream_unit_test;
          disable watchdog_thread;
       end // block: read_response
       //
-      
+
       begin : watchdog_thread
          timeout = 100000;
          while(1) begin
@@ -1133,7 +1160,7 @@ module axis_pkt_to_stream_unit_test;
             @(posedge clk);
          end
       end
-      
+
    join
    @(negedge clk);
    deframer_enable <= 0;
@@ -1335,6 +1362,7 @@ task push_stimulus_beat;
 
    // Get beat from packet work sapce
    beat_in = test_packet.get_beat;
+   //$display("push_stimulus_beat: time: %d, value: %x",time_this_sample,beat_in);
    // Push beat into stimulus FIFO
    axis_stimulus_pre.push_payload(beat_in,tlast);
    // Push beat into golden response FIFO with caclulated dispatch time
@@ -1342,11 +1370,12 @@ task push_stimulus_beat;
    // Update dispatch time
    time_this_sample = time_this_sample  + clks_per_sample;
    // Push beat into golden response FIFO, possibly with TLAST asserted
+   if (tlast) $display("Wrote last beat @ %d",time_this_sample);
    axis_golden_pre.write_beat({time_this_sample,beat_in[31:0]},tlast);
+
    // Update dispatch time
    time_this_sample = time_this_sample  + clks_per_sample;
-   $display("push: time: %d",time_this_sample);
-   
+
 endtask
 
 // Fills packet in workspace with random payload and pushes the headers to the FIFO
@@ -1362,6 +1391,10 @@ task populate_packet;
    test_packet.rewind_payload;
    // Push out Header fields to Stimulus FIFO
    axis_stimulus_pre.push_header(test_packet.get_header());
+   //
+   $display("Created packet: Type: %22s  SeqID: %3d Length: %5d Timestamp: %d",
+	    test_packet.get_packet_type.name(),test_packet.get_seq_id,test_packet.get_length,test_packet.get_timestamp);
+
 endtask // populate_header
 
 // Create new packet workspace object and initialize headers

--- a/lib/axis/axis_pkt_to_stream_unit_test.sv
+++ b/lib/axis/axis_pkt_to_stream_unit_test.sv
@@ -621,7 +621,6 @@ module axis_pkt_to_stream_unit_test;
                                             0,              // STATUS SEQ NUM
                                             0               // VERBOSE
                                             );
-//       $display("STATUS: Received SeqID:0 UNDERFLOW");
 
          status_packet = new;
          status_packet.copy_to_pkt(axis_status_post);
@@ -636,7 +635,6 @@ module axis_pkt_to_stream_unit_test;
                                             2,              // STATUS SEQ NUM
                                             0               // VERBOSE
                                             );
-//       $display("STATUS: Received SeqID:1 LATE");
 
          status_packet = new;
          status_packet.copy_to_pkt(axis_status_post);
@@ -651,7 +649,6 @@ module axis_pkt_to_stream_unit_test;
                                             3,              // STATUS SEQ NUM
                                             0               // VERBOSE
                                             );
-//       $display("STATUS: Received SeqID:2 LATE");
 
          status_packet = new;
          status_packet.copy_to_pkt(axis_status_post);
@@ -668,7 +665,6 @@ module axis_pkt_to_stream_unit_test;
                                             );
 
 
-//       $display("STATUS: Received SeqID:3 LATE");
 
          status_packet = new;
          status_packet.copy_to_pkt(axis_status_post);
@@ -683,7 +679,6 @@ module axis_pkt_to_stream_unit_test;
                                             7,              // STATUS SEQ NUM
                                             0               // VERBOSE
                                             );
-//       $display("STATUS: Received SeqID:4 EOB_ACK");
 
          `INFO("underflow_one_burst_one_clk_per_samp: Good Status");
       end // block: read_status2
@@ -706,7 +701,6 @@ module axis_pkt_to_stream_unit_test;
                                                     i,              // STATUS SEQ NUM
                                                     0               // VERBOSE
                                                     );
-//          $display("CONSUMPTION: Received SeqID:%d ACK",i);
          end
 
          `INFO("underflow_one_burst_one_clk_per_samp: Good Consumption");
@@ -1362,7 +1356,6 @@ task push_stimulus_beat;
 
    // Get beat from packet work sapce
    beat_in = test_packet.get_beat;
-   //$display("push_stimulus_beat: time: %d, value: %x",time_this_sample,beat_in);
    // Push beat into stimulus FIFO
    axis_stimulus_pre.push_payload(beat_in,tlast);
    // Push beat into golden response FIFO with caclulated dispatch time
@@ -1370,7 +1363,6 @@ task push_stimulus_beat;
    // Update dispatch time
    time_this_sample = time_this_sample  + clks_per_sample;
    // Push beat into golden response FIFO, possibly with TLAST asserted
-   if (tlast) $display("Wrote last beat @ %d",time_this_sample);
    axis_golden_pre.write_beat({time_this_sample,beat_in[31:0]},tlast);
 
    // Update dispatch time
@@ -1391,9 +1383,6 @@ task populate_packet;
    test_packet.rewind_payload;
    // Push out Header fields to Stimulus FIFO
    axis_stimulus_pre.push_header(test_packet.get_header());
-   //
-   $display("Created packet: Type: %22s  SeqID: %3d Length: %5d Timestamp: %d",
-	    test_packet.get_packet_type.name(),test_packet.get_seq_id,test_packet.get_length,test_packet.get_timestamp);
 
 endtask // populate_header
 

--- a/lib/axis/axis_status_report.sv
+++ b/lib/axis/axis_status_report.sv
@@ -73,12 +73,12 @@ module axis_status_report
     // When not enabled, Seq Num will be reset.
     always_ff @(posedge clk)
         if(rst) begin
-            seq_num <= 12'd0;
+            seq_num <= 8'd0;
         end else if ((state == S_IDLE) && ~enable_in) begin
             // Disabling block will reset Seq Num as it goes idle.
-            seq_num <= 12'd0;
+            seq_num <= 8'd0;
         end else if ((state == S_PAYLOAD) && axis_status_out.tready) begin
-            seq_num <= seq_num + 12'd1;
+            seq_num <= seq_num + 8'd1;
         end
 
     always_ff @(posedge clk) begin
@@ -89,22 +89,22 @@ module axis_status_report
                 // Spin in this state until the generation of a packet is triggered.
                 S_IDLE: begin
                     if (generate_pkt_in && enable_in)
-                        state <= S_HEADER;
+                      state <= S_HEADER;
                 end
                 // Generate DRaT STATUS Header beat
                 S_HEADER: begin
                     if (axis_status_out.tready)
-                        state <= S_TIME;
+                      state <= S_TIME;
                 end
                 // Generate DRaT STATUS Timestamp beat
                 S_TIME: begin
                     if (axis_status_out.tready)
-                        state <= S_PAYLOAD;
+                      state <= S_PAYLOAD;
                 end
                 // Generate DRaT STATUS Payload beat
                 S_PAYLOAD: begin
                     if (axis_status_out.tready)
-                        state <= S_IDLE;
+                      state <= S_IDLE;
                 end
             endcase // case (state)
         end // else: !if(rst)

--- a/lib/axis/axis_tx_control.sv
+++ b/lib/axis/axis_tx_control.sv
@@ -150,8 +150,7 @@ module axis_tx_control
 
     always_ff @(posedge clk) begin
        if (rst) begin
-          generate_consumption_out <= 1'b1;
-          consumed_seq_num_out <= 0;
+          generate_consumption_out <= 1'b0;
           consumption_counter <= 1;
        end else if (consumption_period == 0) begin
           // Do nothing. No consumption packets generated. Also allows S/W reset of count.
@@ -166,7 +165,6 @@ module axis_tx_control
           // then the seq_num is harmlessly updated to effectively update the original consumption report.
           //
           generate_consumption_out <= 1'b1;
-          consumed_seq_num_out <= beat.seq_num;
           consumption_counter <= 1;
        end else if (consumption_inc) begin
           consumption_counter <= consumption_counter + 1;
@@ -188,6 +186,7 @@ module axis_tx_control
             status_payload_out <= 64'h0;
             axis_stream.tvalid <= 1'b0;
             consumption_inc <= 1'b0;
+            consumed_seq_num_out <= 0;
             state <= S_IDLE;
         end else if (~enable_in) begin
             // Transition to S_ERROR immediatly if not enabled and discard input data
@@ -197,6 +196,7 @@ module axis_tx_control
             generate_pkt_out <= 1'b0;
             status_payload_out <= 64'h0;
             consumption_inc <= 1'b0;
+            consumed_seq_num_out <= 0;
         end else begin
             // Defaults
             axis_stream.tvalid <= 1'b1;
@@ -272,11 +272,13 @@ module axis_tx_control
                             status_payload_out <= status_eob_ack;
                             // Increment consumption counter
                             consumption_inc <= 1'b1;
+                            consumed_seq_num_out <= beat.seq_num;
                         end else if (beat.eop && beat.odd) begin
                             // Odd length Packet is ending this cycle, remain in ODD sample state
                             state <= S_ODD;
                             // Increment consumption counter
                             consumption_inc <= 1'b1;
+                            consumed_seq_num_out <= beat.seq_num;
                         end else begin
                             // Nothing special, move on to the even sample
                             state <= S_EVEN;
@@ -301,12 +303,14 @@ module axis_tx_control
                             status_payload_out <= status_eob_ack;
                             // Increment consumption counter
                             consumption_inc <= 1'b1;
+                            consumed_seq_num_out <= beat.seq_num;
                         end else begin
                             // Nothing special, move on to odd sample (FIFO will pop now)
                             state <= S_ODD;
                             if (beat.eop) begin
                                 // Increment consumption counter
                                 consumption_inc <= 1'b1;
+                               consumed_seq_num_out <= beat.seq_num;
                             end
                         end
                     end // if (axis_stream.tready)
@@ -323,6 +327,7 @@ module axis_tx_control
                         //
                         // Increment consumption counter
                         consumption_inc <= 1'b1;
+                        consumed_seq_num_out <= beat.seq_num;
                         // Time to make error policy decisions.
                         if (beat.eob || error_policy_next_packet_in) begin
                             // Policy dictates if we try to restart on a packet or burst boundry.

--- a/lib/dsp/dependencies.f
+++ b/lib/dsp/dependencies.f
@@ -1,2 +1,1 @@
 ../../misc/ram_dual_port_2clk.sv
-../../../vendor/Xilinx/SRLC32E.v

--- a/lib/dsp/dsp_1_channel.sv
+++ b/lib/dsp/dsp_1_channel.sv
@@ -115,7 +115,6 @@ module dsp_1_channel
        .RX_TIME_FIFO_SIZE(4),  // Default from axis_stream_to_pkt_wrapper
        .RX_SAMPLE_FIFO_SIZE(13),  // Default from axis_stream_to_pkt_wrapper
        .RX_PACKET_FIFO_SIZE(8),  // Default from axis_stream_to_pkt_wrapper
-       .RX_DATA_FIFO_SIZE(10),
        .IQ_WIDTH(16)  // Default from axis_stream_to_pkt_wrapper
        )
    dsp_rx_i0


### PR DESCRIPTION
Changes to axis_tx_control.sv that solve issues with consumption generated ACK's:
- On reset do not assert `generate_consumption_out`
- Move `consumed_seq_num_out` to a different clocked block to remove a cycle of delay that makes the value stale.

Changes to axis_status_report.sv:
- Fix (legacy) miss declaration of SeqID size (12bits instead of 8bits). This caused to functional issue but was confusing and stale.

Changes to dependencies.f:
- Current sim environment doesn't use this path anymore (Legacy cruft)

Changes to dsp_1_channel.sv:
- Remove legacy param that no longer exists on rx_dsp. Leave top level param to not cause potential breakage in any legacy use. (TBH Not sure if I should cause this possible breakage to call out this change)

Changes to axis_tx_control_unit_test.sv:
- Fix lots of bit rot...this has been broken for too long, and the chnages that caused this to stop working are so old it's hard to trace them.
- Tightened the windows on a few assertions here also.

Should also add this duplicates PR#47 which fixes a specific issue in a proprietary system implemented with this code that has been verified in that artifact. PR#47 will be retried when this is merged as DUPE.
